### PR TITLE
Fix/alternate pages on details pages

### DIFF
--- a/.changeset/chilly-crabs-watch.md
+++ b/.changeset/chilly-crabs-watch.md
@@ -1,0 +1,9 @@
+---
+'@o2s/integrations.strapi-cms': patch
+'@o2s/integrations.mocked': patch
+'@o2s/api-harmonization': patch
+'@o2s/framework': patch
+'@o2s/frontend': patch
+---
+
+fixed an issue with alternative URLs for pages - on pages with dynamic URLs (e.g. /cases/(.+)) switching to another locale caused route to change to /cases/(.+) instead of /cases/12345

--- a/apps/api-harmonization/src/models/cms.ts
+++ b/apps/api-harmonization/src/models/cms.ts
@@ -1,4 +1,4 @@
-import { Config, Integration } from '@o2s/integrations.strapi-cms/integration';
+import { Config, Integration } from '@o2s/integrations.mocked/integration';
 
 import { ApiConfig } from '@o2s/framework/modules';
 

--- a/apps/api-harmonization/src/models/cms.ts
+++ b/apps/api-harmonization/src/models/cms.ts
@@ -1,4 +1,4 @@
-import { Config, Integration } from '@o2s/integrations.mocked/integration';
+import { Config, Integration } from '@o2s/integrations.strapi-cms/integration';
 
 import { ApiConfig } from '@o2s/framework/modules';
 

--- a/apps/api-harmonization/src/modules/page/page.mapper.ts
+++ b/apps/api-harmonization/src/modules/page/page.mapper.ts
@@ -7,7 +7,7 @@ export const mapPage = (
     footer: CMS.Model.Footer.Footer,
     page: CMS.Model.Page.Page,
     mainLocale: string,
-    alternatePages: { page: CMS.Model.Page.Page; locale: string }[] = [],
+    alternatePages: CMS.Model.Page.Page[] = [],
 ): Page => {
     const alternativeUrls: { [key: string]: string } = {
         [mainLocale]: page.slug,
@@ -15,8 +15,8 @@ export const mapPage = (
 
     const locales = [...alternatePages.map(({ locale }) => locale), mainLocale];
 
-    alternatePages.forEach(({ page: alternatePage, locale }) => {
-        alternativeUrls[locale] = alternatePage.slug;
+    alternatePages.forEach((p) => {
+        alternativeUrls[p.locale] = p.slug;
     });
 
     return {

--- a/apps/frontend/src/app/[locale]/[[...slug]]/layout.tsx
+++ b/apps/frontend/src/app/[locale]/[[...slug]]/layout.tsx
@@ -35,8 +35,6 @@ export default async function RootLayout({ children, params }: Props) {
         return notFound();
     }
 
-    console.log(data.alternativeUrls);
-
     return (
         <div className="flex flex-col min-h-dvh">
             <Header headerData={common.header} alternativeUrls={data?.alternativeUrls} user={session.user} />

--- a/apps/frontend/src/app/[locale]/[[...slug]]/layout.tsx
+++ b/apps/frontend/src/app/[locale]/[[...slug]]/layout.tsx
@@ -1,3 +1,4 @@
+import { notFound } from 'next/navigation';
 import React from 'react';
 
 import { sdk } from '@/api/sdk';
@@ -29,6 +30,12 @@ export default async function RootLayout({ children, params }: Props) {
         { 'x-locale': locale },
         session.accessToken,
     );
+
+    if (!data) {
+        return notFound();
+    }
+
+    console.log(data.alternativeUrls);
 
     return (
         <div className="flex flex-col min-h-dvh">

--- a/packages/framework/src/modules/cms/cms.request.ts
+++ b/packages/framework/src/modules/cms/cms.request.ts
@@ -19,6 +19,11 @@ export class GetCmsPageParams {
 export class GetCmsPagesParams {
     locale!: string;
 }
+export class GetCmsAlternativePagesParams {
+    id!: string;
+    slug!: string;
+    locale!: string;
+}
 
 export class GetCmsLoginPageParams {
     locale!: string;

--- a/packages/framework/src/modules/cms/cms.service.ts
+++ b/packages/framework/src/modules/cms/cms.service.ts
@@ -17,6 +17,8 @@ export abstract class CmsService {
 
     abstract getPages(options: CMS.Request.GetCmsPagesParams): Observable<CMS.Model.Page.Page[]>;
 
+    abstract getAlternativePages(options: CMS.Request.GetCmsEntryParams): Observable<CMS.Model.Page.Page[]>;
+
     abstract getLoginPage(options: CMS.Request.GetCmsLoginPageParams): Observable<CMS.Model.LoginPage.LoginPage>;
 
     abstract getHeader(options: CMS.Request.GetCmsHeaderParams): Observable<CMS.Model.Header.Header>;

--- a/packages/framework/src/modules/cms/models/page.model.ts
+++ b/packages/framework/src/modules/cms/models/page.model.ts
@@ -3,6 +3,7 @@ import { Models } from '@o2s/framework/modules';
 export class Page {
     id!: string;
     slug!: string;
+    locale!: string;
     template!: PageTemplate;
     updatedAt!: string;
     seo!: Models.SEO.Page;

--- a/packages/integrations/mocked/src/modules/cms/cms.service.ts
+++ b/packages/integrations/mocked/src/modules/cms/cms.service.ts
@@ -14,7 +14,7 @@ import { mapInvoiceListComponent } from './mappers/cms.invoice-list.mapper';
 import { mapLoginPage } from './mappers/cms.login-page.mapper';
 import { mapNotificationDetailsComponent } from './mappers/cms.notification-details.mapper';
 import { mapNotificationListComponent } from './mappers/cms.notification-list.mapper';
-import { getAllPages, mapPage } from './mappers/cms.page.mapper';
+import { getAllPages, getAlternativePages, mapPage } from './mappers/cms.page.mapper';
 import { mapPaymentsHistoryComponent } from './mappers/cms.payments-history.mapper';
 import { mapPaymentsSummaryComponent } from './mappers/cms.payments-summary.mapper';
 import { mapResourceDetailsComponent } from './mappers/cms.resource-details.mapper';
@@ -44,6 +44,10 @@ export class CmsService implements CMS.Service {
 
     getPages(options: CMS.Request.GetCmsPagesParams) {
         return of(getAllPages(options.locale));
+    }
+
+    getAlternativePages(options: CMS.Request.GetCmsAlternativePagesParams) {
+        return of(getAlternativePages(options.id, options.slug, options.locale));
     }
 
     getLoginPage(options: CMS.Request.GetCmsLoginPageParams) {

--- a/packages/integrations/mocked/src/modules/cms/mappers/cms.page.mapper.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/cms.page.mapper.ts
@@ -3,6 +3,7 @@ import { CMS } from '@o2s/framework/modules';
 const PAGE_DASHBOARD_PL: CMS.Model.Page.Page = {
     slug: '/',
     id: '1',
+    locale: 'pl',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -55,6 +56,7 @@ const PAGE_DASHBOARD_PL: CMS.Model.Page.Page = {
 const PAGE_DASHBOARD_EN: CMS.Model.Page.Page = {
     slug: '/',
     id: '1',
+    locale: 'en',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -107,6 +109,7 @@ const PAGE_DASHBOARD_EN: CMS.Model.Page.Page = {
 const PAGE_DASHBOARD_DE: CMS.Model.Page.Page = {
     slug: '/',
     id: '1',
+    locale: 'de',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -159,6 +162,7 @@ const PAGE_DASHBOARD_DE: CMS.Model.Page.Page = {
 const PAGE_TICKET_LIST_EN: CMS.Model.Page.Page = {
     id: '2',
     slug: '/cases',
+    locale: 'en',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -197,6 +201,7 @@ const PAGE_TICKET_LIST_EN: CMS.Model.Page.Page = {
 const PAGE_TICKET_LIST_DE: CMS.Model.Page.Page = {
     id: '2',
     slug: '/faelle',
+    locale: 'de',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -235,6 +240,7 @@ const PAGE_TICKET_LIST_DE: CMS.Model.Page.Page = {
 const PAGE_TICKET_LIST_PL: CMS.Model.Page.Page = {
     id: '2',
     slug: '/zgloszenia',
+    locale: 'pl',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -273,6 +279,7 @@ const PAGE_TICKET_LIST_PL: CMS.Model.Page.Page = {
 const PAGE_TICKET_DETAILS_EN: CMS.Model.Page.Page = {
     id: '3',
     slug: '/cases/(.+)',
+    locale: 'en',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -311,6 +318,7 @@ const PAGE_TICKET_DETAILS_EN: CMS.Model.Page.Page = {
 const PAGE_TICKET_DETAILS_DE: CMS.Model.Page.Page = {
     id: '3',
     slug: '/faelle/(.+)',
+    locale: 'de',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -349,6 +357,7 @@ const PAGE_TICKET_DETAILS_DE: CMS.Model.Page.Page = {
 const PAGE_TICKET_DETAILS_PL: CMS.Model.Page.Page = {
     id: '3',
     slug: '/zgloszenia/(.+)',
+    locale: 'pl',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -387,6 +396,7 @@ const PAGE_TICKET_DETAILS_PL: CMS.Model.Page.Page = {
 const PAGE_NOTIFICATION_LIST_EN: CMS.Model.Page.Page = {
     id: '4',
     slug: '/notifications',
+    locale: 'en',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -425,6 +435,7 @@ const PAGE_NOTIFICATION_LIST_EN: CMS.Model.Page.Page = {
 const PAGE_NOTIFICATION_LIST_DE: CMS.Model.Page.Page = {
     id: '4',
     slug: '/benachrichtigungen',
+    locale: 'de',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -463,6 +474,7 @@ const PAGE_NOTIFICATION_LIST_DE: CMS.Model.Page.Page = {
 const PAGE_NOTIFICATION_LIST_PL: CMS.Model.Page.Page = {
     id: '4',
     slug: '/powiadomienia',
+    locale: 'pl',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -501,6 +513,7 @@ const PAGE_NOTIFICATION_LIST_PL: CMS.Model.Page.Page = {
 const PAGE_INVOICE_LIST_EN: CMS.Model.Page.Page = {
     id: '5',
     slug: '/invoices',
+    locale: 'en',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -552,6 +565,7 @@ const PAGE_INVOICE_LIST_EN: CMS.Model.Page.Page = {
 const PAGE_INVOICE_LIST_DE: CMS.Model.Page.Page = {
     id: '5',
     slug: '/rechnungen',
+    locale: 'de',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -603,6 +617,7 @@ const PAGE_INVOICE_LIST_DE: CMS.Model.Page.Page = {
 const PAGE_INVOICE_LIST_PL: CMS.Model.Page.Page = {
     id: '5',
     slug: '/rachunki',
+    locale: 'pl',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -654,6 +669,7 @@ const PAGE_INVOICE_LIST_PL: CMS.Model.Page.Page = {
 const PAGE_NOTIFICATION_DETAILS_EN: CMS.Model.Page.Page = {
     id: '6',
     slug: '/notifications/(.+)',
+    locale: 'en',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -692,6 +708,7 @@ const PAGE_NOTIFICATION_DETAILS_EN: CMS.Model.Page.Page = {
 const PAGE_NOTIFICATION_DETAILS_DE: CMS.Model.Page.Page = {
     id: '6',
     slug: '/benachrichtigungen/(.+)',
+    locale: 'de',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -730,6 +747,7 @@ const PAGE_NOTIFICATION_DETAILS_DE: CMS.Model.Page.Page = {
 const PAGE_NOTIFICATION_DETAILS_PL: CMS.Model.Page.Page = {
     id: '6',
     slug: '/powiadomienia/(.+)',
+    locale: 'pl',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -768,6 +786,7 @@ const PAGE_NOTIFICATION_DETAILS_PL: CMS.Model.Page.Page = {
 const PAGE_USER_ACCOUNT_EN: CMS.Model.Page.Page = {
     id: '7',
     slug: '/user-account',
+    locale: 'en',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -802,6 +821,7 @@ const PAGE_USER_ACCOUNT_EN: CMS.Model.Page.Page = {
 const PAGE_USER_ACCOUNT_DE: CMS.Model.Page.Page = {
     id: '7',
     slug: '/benutzerkonto',
+    locale: 'de',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -836,6 +856,7 @@ const PAGE_USER_ACCOUNT_DE: CMS.Model.Page.Page = {
 const PAGE_USER_ACCOUNT_PL: CMS.Model.Page.Page = {
     id: '7',
     slug: '/konto-uzytkownika',
+    locale: 'pl',
     seo: {
         noIndex: false,
         noFollow: false,
@@ -884,19 +905,19 @@ export const mapPage = (slug: string, locale: string): CMS.Model.Page.Page | und
         case slug.match(/\/cases\/.+/)?.[0]:
             return {
                 ...PAGE_TICKET_DETAILS_EN,
-                slug: `/\/cases/${slug.match(/(.+)\/(.+)/)?.[2]}`,
+                slug: `/cases/${slug.match(/(.+)\/(.+)/)?.[2]}`,
                 updatedAt: '2025-01-01',
             };
         case slug.match(/\/faelle\/.+/)?.[0]:
             return {
                 ...PAGE_TICKET_DETAILS_DE,
-                slug: `/\/faelle/${slug.match(/(.+)\/(.+)/)?.[2]}`,
+                slug: `/faelle/${slug.match(/(.+)\/(.+)/)?.[2]}`,
                 updatedAt: '2025-01-01',
             };
         case slug.match(/\/zgloszenia\/.+/)?.[0]:
             return {
                 ...PAGE_TICKET_DETAILS_PL,
-                slug: `/\/zgloszenia/${slug.match(/(.+)\/(.+)/)?.[2]}`,
+                slug: `/zgloszenia/${slug.match(/(.+)\/(.+)/)?.[2]}`,
                 updatedAt: '2025-01-01',
             };
 
@@ -910,20 +931,20 @@ export const mapPage = (slug: string, locale: string): CMS.Model.Page.Page | und
         case slug.match(/\/notifications\/.+/)?.[0]:
             return {
                 ...PAGE_NOTIFICATION_DETAILS_EN,
-                slug: `/\/notifications/${slug.match(/(.+)\/(.+)/)?.[2]}`,
+                slug: `/notifications/${slug.match(/(.+)\/(.+)/)?.[2]}`,
                 updatedAt: '2025-01-01',
             };
 
         case slug.match(/\/benachrichtigungen\/.+/)?.[0]:
             return {
                 ...PAGE_NOTIFICATION_DETAILS_DE,
-                slug: `/\/benachrichtigungen/${slug.match(/(.+)\/(.+)/)?.[2]}`,
+                slug: `/benachrichtigungen/${slug.match(/(.+)\/(.+)/)?.[2]}`,
                 updatedAt: '2025-01-01',
             };
         case slug.match(/\/powiadomienia\/.+/)?.[0]:
             return {
                 ...PAGE_NOTIFICATION_DETAILS_PL,
-                slug: `/\/powiadomienia/${slug.match(/(.+)\/(.+)/)?.[2]}`,
+                slug: `/powiadomienia/${slug.match(/(.+)\/(.+)/)?.[2]}`,
                 updatedAt: '2025-01-01',
             };
 
@@ -945,6 +966,7 @@ export const mapPage = (slug: string, locale: string): CMS.Model.Page.Page | und
             return undefined;
     }
 };
+
 export const getAllPages = (locale: string): CMS.Model.Page.Page[] => {
     switch (locale) {
         case 'pl':
@@ -980,4 +1002,38 @@ export const getAllPages = (locale: string): CMS.Model.Page.Page[] => {
         default:
             return [];
     }
+};
+
+export const getAlternativePages = (id: string, slug: string, locale: string): CMS.Model.Page.Page[] => {
+    return [
+        PAGE_DASHBOARD_PL,
+        PAGE_TICKET_LIST_PL,
+        PAGE_TICKET_DETAILS_PL,
+        PAGE_NOTIFICATION_LIST_PL,
+        PAGE_NOTIFICATION_DETAILS_PL,
+        PAGE_INVOICE_LIST_PL,
+        PAGE_USER_ACCOUNT_PL,
+        PAGE_DASHBOARD_DE,
+        PAGE_TICKET_LIST_DE,
+        PAGE_TICKET_DETAILS_DE,
+        PAGE_NOTIFICATION_LIST_DE,
+        PAGE_NOTIFICATION_DETAILS_DE,
+        PAGE_INVOICE_LIST_DE,
+        PAGE_USER_ACCOUNT_DE,
+        PAGE_DASHBOARD_EN,
+        PAGE_TICKET_LIST_EN,
+        PAGE_TICKET_DETAILS_EN,
+        PAGE_NOTIFICATION_LIST_EN,
+        PAGE_NOTIFICATION_DETAILS_EN,
+        PAGE_INVOICE_LIST_EN,
+        PAGE_USER_ACCOUNT_EN,
+    ]
+        .filter((page) => page.id === id)
+        .map((page) => mapPage(page.slug, locale)!)
+        .map((page) => {
+            return {
+                ...page,
+                slug: page.slug.replace('(.+)', slug.match(/(.+)\/(.+)/)?.[2] || ''),
+            };
+        });
 };

--- a/packages/integrations/strapi-cms/generated/strapi.ts
+++ b/packages/integrations/strapi-cms/generated/strapi.ts
@@ -6130,6 +6130,10 @@ export type GetHeaderQuery = {
     configurableTexts?: { actions: { clear: string; apply: string } };
 };
 
+export type GetLocalesQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GetLocalesQuery = { i18NLocales: Array<{ code?: string }> };
+
 export type GetLoginPageQueryVariables = Exact<{
     locale: Scalars['I18NLocaleCode']['input'];
 }>;
@@ -7009,6 +7013,13 @@ export const GetHeaderDocument = gql`
     }
     ${HeaderFragmentDoc}
 `;
+export const GetLocalesDocument = gql`
+    query getLocales {
+        i18NLocales {
+            code
+        }
+    }
+`;
 export const GetLoginPageDocument = gql`
     query getLoginPage($locale: I18NLocaleCode!) {
         loginPage(locale: $locale) {
@@ -7052,6 +7063,7 @@ const GetAppConfigDocumentString = print(GetAppConfigDocument);
 const GetComponentDocumentString = print(GetComponentDocument);
 const GetFooterDocumentString = print(GetFooterDocument);
 const GetHeaderDocumentString = print(GetHeaderDocument);
+const GetLocalesDocumentString = print(GetLocalesDocument);
 const GetLoginPageDocumentString = print(GetLoginPageDocument);
 const GetPageDocumentString = print(GetPageDocument);
 const GetPagesDocumentString = print(GetPagesDocument);
@@ -7137,6 +7149,27 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
                         ...wrappedRequestHeaders,
                     }),
                 'getHeader',
+                'query',
+                variables,
+            );
+        },
+        getLocales(
+            variables?: GetLocalesQueryVariables,
+            requestHeaders?: GraphQLClientRequestHeaders,
+        ): Promise<{
+            data: GetLocalesQuery;
+            errors?: GraphQLError[];
+            extensions?: any;
+            headers: Headers;
+            status: number;
+        }> {
+            return withWrapper(
+                (wrappedRequestHeaders) =>
+                    client.rawRequest<GetLocalesQuery>(GetLocalesDocumentString, variables, {
+                        ...requestHeaders,
+                        ...wrappedRequestHeaders,
+                    }),
+                'getLocales',
                 'query',
                 variables,
             );

--- a/packages/integrations/strapi-cms/src/modules/cms/cms.service.ts
+++ b/packages/integrations/strapi-cms/src/modules/cms/cms.service.ts
@@ -145,6 +145,22 @@ export class CmsService implements CMS.Service {
         );
     }
 
+    getAlternativePages(options: CMS.Request.GetCmsAlternativePagesParams) {
+        // TODO: implement
+        const pages = this.graphqlService.getPages({
+            locale: options.locale,
+        });
+
+        return forkJoin([pages]).pipe(
+            map(([pages]) => {
+                if (!pages?.data?.pages?.length) {
+                    throw new NotFoundException();
+                }
+                return pages.data.pages.map((page) => mapPage(page));
+            }),
+        );
+    }
+
     getLoginPage(options: CMS.Request.GetCmsLoginPageParams) {
         const key = `login-page-${options.locale}`;
         return this.getCachedComponent(key, () => {

--- a/packages/integrations/strapi-cms/src/modules/cms/cms.service.ts
+++ b/packages/integrations/strapi-cms/src/modules/cms/cms.service.ts
@@ -3,9 +3,10 @@ import { ConfigService } from '@nestjs/config';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore module type mismatch
 import { parse, stringify } from 'flatted';
-import { Observable, forkJoin, from, map, mergeMap, of } from 'rxjs';
+import { Observable, concatMap, forkJoin, from, map, mergeMap, of } from 'rxjs';
 
-import { CMS, Cache } from '@o2s/framework/modules';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { CMS, Cache, Models } from '@o2s/framework/modules';
 
 import { mapAppConfig } from './mappers/cms.app-config.mapper';
 import { mapFooter } from './mappers/cms.footer.mapper';
@@ -26,6 +27,7 @@ import { mapResourceListComponent } from './mappers/components/cms.resource-list
 import { mapTicketDetailsComponent } from './mappers/components/cms.ticket-details.mapper';
 import { mapTicketListComponent } from './mappers/components/cms.ticket-list.mapper';
 import { mapUserAccountComponent } from './mappers/components/cms.user-account.mapper';
+import { PageFragment } from '@/generated/strapi';
 import { Service as GraphqlService } from '@/modules/graphql';
 
 @Injectable()
@@ -146,17 +148,37 @@ export class CmsService implements CMS.Service {
     }
 
     getAlternativePages(options: CMS.Request.GetCmsAlternativePagesParams) {
-        // TODO: implement
-        const pages = this.graphqlService.getPages({
-            locale: options.locale,
-        });
+        const locales = this.graphqlService.getLocales();
 
-        return forkJoin([pages]).pipe(
-            map(([pages]) => {
-                if (!pages?.data?.pages?.length) {
-                    throw new NotFoundException();
-                }
-                return pages.data.pages.map((page) => mapPage(page));
+        return forkJoin([locales]).pipe(
+            concatMap(([locales]) => {
+                return forkJoin(
+                    locales.data.i18NLocales.map((locale) =>
+                        this.graphqlService.getPages({
+                            locale: locale.code,
+                        }),
+                    ),
+                ).pipe(
+                    map((pages) => {
+                        if (!pages?.length) {
+                            throw new NotFoundException();
+                        }
+
+                        const allPages = pages.reduce<PageFragment[]>((prev, current) => {
+                            return [...prev, ...current.data.pages];
+                        }, []);
+
+                        return allPages
+                            .filter((page) => page.documentId === options.id)
+                            .map((page) => mapPage(page))
+                            .map((page) => {
+                                return {
+                                    ...page,
+                                    slug: page.slug.replace('(.+)', options.slug.match(/(.+)\/(.+)/)?.[2] || ''),
+                                };
+                            });
+                    }),
+                );
             }),
         );
     }

--- a/packages/integrations/strapi-cms/src/modules/cms/graphql/queries/getLocales.graphql
+++ b/packages/integrations/strapi-cms/src/modules/cms/graphql/queries/getLocales.graphql
@@ -1,0 +1,5 @@
+query getLocales {
+    i18NLocales {
+        code
+    }
+}

--- a/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.page.mapper.ts
+++ b/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.page.mapper.ts
@@ -30,6 +30,32 @@ export const mapPage = (data: PageFragment): CMS.Model.Page.Page => {
     };
 };
 
+export const mapAlternativePages = (data: PageFragment): CMS.Model.Page.Page => {
+    const template = mapTemplate(data.template[0]);
+
+    if (!template) throw new NotFoundException();
+
+    return {
+        id: data.documentId,
+        slug: data.slug,
+        locale: data.locale!,
+        template: template,
+        updatedAt: data.updatedAt,
+        seo: {
+            title: data.SEO!.title,
+            noIndex: data.SEO!.noIndex,
+            noFollow: data.SEO!.noFollow,
+            description: data.SEO!.description,
+            keywords: data.SEO!.keywords?.map((keyword) => keyword.keyword) || [],
+            image: data.SEO!.image,
+        },
+        hasOwnTitle: data.hasOwnTitle,
+        parent: {
+            slug: data.parent?.slug ?? '',
+        },
+    };
+};
+
 const mapTemplate = (template?: TemplateFragment): CMS.Model.Page.PageTemplate => {
     if (!template) throw new NotFoundException();
 

--- a/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.page.mapper.ts
+++ b/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.page.mapper.ts
@@ -10,10 +10,11 @@ export const mapPage = (data: PageFragment): CMS.Model.Page.Page => {
     if (!template) throw new NotFoundException();
 
     return {
+        id: data.documentId,
         slug: data.slug,
+        locale: data.locale!,
         template: template,
         updatedAt: data.updatedAt,
-        id: data.documentId,
         seo: {
             title: data.SEO!.title,
             noIndex: data.SEO!.noIndex,

--- a/packages/integrations/strapi-cms/src/modules/graphql/graphql.service.ts
+++ b/packages/integrations/strapi-cms/src/modules/graphql/graphql.service.ts
@@ -29,8 +29,16 @@ export class GraphqlService {
         return this.sdk.getAppConfig(params);
     }
 
+    public getLocales() {
+        return this.sdk.getLocales();
+    }
+
     public getPage(params: GetPageQueryVariables) {
         return this.sdk.getPage(params);
+    }
+
+    public getPages(params: GetPagesQueryVariables) {
+        return this.sdk.getPages(params);
     }
 
     public getLoginPage(params: GetLoginPageQueryVariables) {
@@ -43,10 +51,6 @@ export class GraphqlService {
 
     public getFooter(params: GetFooterQueryVariables) {
         return this.sdk.getFooter(params);
-    }
-
-    public getPages(params: GetPagesQueryVariables) {
-        return this.sdk.getPages(params);
     }
 
     public getComponent(params: GetComponentQueryVariables) {


### PR DESCRIPTION
**What does this PR do?**

- fixes an issue with alternative URLs for pages - on pages with dynamic URLs (e.g. `/cases/(.+)`) switching to another locale caused route to change to  `/cases/(.+)` instead of  `/cases/12345`

