### PR TITLE
fix(frontend): fixed alternative urls for pages not working when changing locale

### DIFF
--- a/.changeset/chilled-pears-crash.md
+++ b/.changeset/chilled-pears-crash.md
@@ -1,0 +1,5 @@
+---
+'@o2s/frontend': patch
+---
+
+fixed alternative urls for pages not working when changing locale

--- a/apps/frontend/src/app/[locale]/[[...slug]]/page.tsx
+++ b/apps/frontend/src/app/[locale]/[[...slug]]/page.tsx
@@ -12,6 +12,7 @@ import { generateSeo } from '@/utils/seo';
 
 import { auth, signIn } from '@/auth';
 
+import { Client } from '@/components/Client';
 import { PageTemplate } from '@/components/PageTemplate/PageTemplate';
 
 interface Props {
@@ -85,6 +86,8 @@ export default async function Page({ params }: Props) {
 
         return (
             <main className="flex flex-col gap-6 row-start-2 items-center sm:items-start">
+                <Client page={data} />
+
                 {!data.hasOwnTitle && (
                     <div className="flex flex-col gap-6 w-full">
                         <Typography variant="h1" asChild>

--- a/apps/frontend/src/app/[locale]/layout.tsx
+++ b/apps/frontend/src/app/[locale]/layout.tsx
@@ -54,7 +54,7 @@ export default async function RootLayout({ children, params }: Props) {
         <html lang={locale} className={inter.className}>
             <body>
                 {/*@see https://github.com/nextauthjs/next-auth/issues/9504#issuecomment-2516665386*/}
-                <SessionProvider key={session?.user?.id} session={session}>
+                <SessionProvider key={session?.user?.id} session={session} refetchOnWindowFocus={false}>
                     <GlobalProvider config={init} locale={locale}>
                         <div className="flex flex-col min-h-dvh">
                             <Header headerData={init.common.header} />

--- a/apps/frontend/src/components/Auth/Toolbar/LocaleSwitcher.tsx
+++ b/apps/frontend/src/components/Auth/Toolbar/LocaleSwitcher.tsx
@@ -13,17 +13,17 @@ import { useGlobalContext } from '@/providers/GlobalProvider';
 
 import { ToolbarProps } from './Toolbar.types';
 
-export const LocaleSwitcher: React.FC<ToolbarProps> = ({ alternativeUrls, label = 'Language' }) => {
+export const LocaleSwitcher: React.FC<ToolbarProps> = ({ label = 'Language' }) => {
     const pathname = usePathname();
     const searchParams = useSearchParams();
     const router = useRouter();
 
-    const { config } = useGlobalContext();
+    const { config, alternativeUrls } = useGlobalContext();
 
     const currentLocale = useLocale();
 
     const handleLocaleChange = (locale: string) => {
-        const alternative = alternativeUrls?.[locale];
+        const alternative = alternativeUrls.values?.[locale];
         const url = alternative || pathname;
 
         router.push(

--- a/apps/frontend/src/components/Auth/Toolbar/Toolbar.types.ts
+++ b/apps/frontend/src/components/Auth/Toolbar/Toolbar.types.ts
@@ -1,6 +1,3 @@
 export interface ToolbarProps {
-    alternativeUrls?: {
-        [key: string]: string;
-    };
     label: string;
 }

--- a/apps/frontend/src/components/Client.tsx
+++ b/apps/frontend/src/components/Client.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Modules } from '@o2s/api-harmonization';
+import React, { useEffect } from 'react';
+
+import { useGlobalContext } from '@/providers/GlobalProvider';
+
+interface ClientProps {
+    page?: Modules.Page.Model.PageData;
+}
+
+export const Client: React.FC<ClientProps> = ({ page }) => {
+    const { alternativeUrls } = useGlobalContext();
+
+    // since locale switcher is placed inside the layout, we cannot access page-specific data there,
+    // so pasing of alternative urls has to be done on client side (because layouts are not re-rendered on route change)
+    useEffect(() => {
+        page && alternativeUrls.set(page.alternativeUrls);
+    }, [alternativeUrls, page]);
+
+    return null;
+};

--- a/apps/frontend/src/providers/GlobalProvider.tsx
+++ b/apps/frontend/src/providers/GlobalProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Modules } from '@o2s/api-harmonization';
-import React, { ReactNode, createContext, useContext } from 'react';
+import React, { ReactNode, createContext, useContext, useState } from 'react';
 
 import { PriceService, usePriceService } from '@/hooks/usePriceService';
 
@@ -14,14 +14,37 @@ interface GlobalProviderProps {
 export interface GlobalContextType {
     config: Modules.Page.Model.Init;
     priceService: PriceService;
+    alternativeUrls: {
+        values: {
+            [key: string]: string;
+        };
+        set: (values: { [key: string]: string }) => void;
+    };
 }
 
 export const GlobalContext = createContext({} as GlobalContextType);
 
 export const GlobalProvider = ({ config, locale, children }: GlobalProviderProps) => {
+    const [alternativeUrls, setAlternativeUrls] = useState<{
+        [key: string]: string;
+    }>({});
+
     const priceService = usePriceService(locale);
 
-    return <GlobalContext.Provider value={{ config, priceService }}>{children}</GlobalContext.Provider>;
+    return (
+        <GlobalContext.Provider
+            value={{
+                config,
+                priceService,
+                alternativeUrls: {
+                    values: alternativeUrls,
+                    set: setAlternativeUrls,
+                },
+            }}
+        >
+            {children}
+        </GlobalContext.Provider>
+    );
 };
 
 export const useGlobalContext = () => useContext(GlobalContext);


### PR DESCRIPTION
**What does this PR do?**

- [x] fixes alternative urls for pages not working when changing locale - due to `LocaleSwitcher` being placed inside the layout it was not re-rendered on route change; there is also no access to page-specific data on the layout level so the locale swticher has to be updated client-side
