### PR TITLE
fix: fixed text wrapping in table headers on larger screens

### DIFF
--- a/.changeset/silly-candies-divide.md
+++ b/.changeset/silly-candies-divide.md
@@ -1,0 +1,5 @@
+---
+'@o2s/frontend': minor
+---
+
+fixed text wrapping in table headers on larger screens

--- a/apps/frontend/src/blocks/InvoiceList/InvoiceList.client.tsx
+++ b/apps/frontend/src/blocks/InvoiceList/InvoiceList.client.tsx
@@ -95,7 +95,7 @@ export const InvoiceListPure: React.FC<InvoiceListPureProps> = ({ locale, access
                                                     <TableHead
                                                         key={column.id}
                                                         className={cn(
-                                                            'py-3 px-4 text-sm text-muted-foreground',
+                                                            'py-3 px-4 text-sm text-muted-foreground md:text-nowrap',
                                                             column.id === 'totalAmountDue' && 'text-right',
                                                             column.id === 'amountToPay' && 'text-right',
                                                         )}
@@ -104,7 +104,7 @@ export const InvoiceListPure: React.FC<InvoiceListPureProps> = ({ locale, access
                                                     </TableHead>
                                                 ))}
                                                 {data.table.data.actions && (
-                                                    <TableHead className="py-3 px-4 text-sm text-muted-foreground">
+                                                    <TableHead className="py-3 px-4 text-sm text-muted-foreground md:text-nowrap">
                                                         {data.table.data.actions.title}
                                                     </TableHead>
                                                 )}

--- a/apps/frontend/src/blocks/NotificationList/NotificationList.client.tsx
+++ b/apps/frontend/src/blocks/NotificationList/NotificationList.client.tsx
@@ -78,13 +78,13 @@ export const NotificationListPure: React.FC<NotificationListPureProps> = ({ loca
                                             {data.table.columns.map((column) => (
                                                 <TableHead
                                                     key={column.id}
-                                                    className="py-3 px-4 text-sm text-muted-foreground"
+                                                    className="py-3 px-4 text-sm text-muted-foreground md:text-nowrap"
                                                 >
                                                     {column.id !== 'status' ? column.title : null}
                                                 </TableHead>
                                             ))}
                                             {data.table.actions && (
-                                                <TableHead className="py-3 px-4 text-sm text-muted-foreground">
+                                                <TableHead className="py-3 px-4 text-sm text-muted-foreground md:text-nowrap">
                                                     {data.table.actions.title}
                                                 </TableHead>
                                             )}

--- a/apps/frontend/src/blocks/OrderList/OrderList.client.tsx
+++ b/apps/frontend/src/blocks/OrderList/OrderList.client.tsx
@@ -91,7 +91,7 @@ export const OrderListPure: React.FC<OrderListPureProps> = ({ locale, accessToke
                                                         return (
                                                             <TableHead
                                                                 key={column.id}
-                                                                className="py-3 px-4 text-sm font-medium text-muted-foreground text-right"
+                                                                className="py-3 px-4 text-sm font-medium text-muted-foreground text-right md:text-nowrap"
                                                             >
                                                                 {column.title}
                                                             </TableHead>
@@ -100,7 +100,7 @@ export const OrderListPure: React.FC<OrderListPureProps> = ({ locale, accessToke
                                                         return (
                                                             <TableHead
                                                                 key={column.id}
-                                                                className="py-3 px-4 text-sm font-medium text-muted-foreground"
+                                                                className="py-3 px-4 text-sm font-medium text-muted-foreground md:text-nowrap"
                                                             >
                                                                 {column.title}
                                                             </TableHead>
@@ -108,7 +108,7 @@ export const OrderListPure: React.FC<OrderListPureProps> = ({ locale, accessToke
                                                 }
                                             })}
                                             {data.table.actions && (
-                                                <TableHead className="py-3 px-4 text-sm font-medium text-muted-foreground">
+                                                <TableHead className="py-3 px-4 text-sm font-medium text-muted-foreground md:text-nowrap">
                                                     {data.table.actions.title}
                                                 </TableHead>
                                             )}

--- a/apps/frontend/src/blocks/TicketList/TicketList.client.tsx
+++ b/apps/frontend/src/blocks/TicketList/TicketList.client.tsx
@@ -90,13 +90,13 @@ export const TicketListPure: React.FC<TicketListPureProps> = ({ locale, accessTo
                                             {data.table.columns.map((column) => (
                                                 <TableHead
                                                     key={column.id}
-                                                    className="py-3 px-4 text-sm font-medium text-muted-foreground"
+                                                    className="py-3 px-4 text-sm font-medium text-muted-foreground md:text-nowrap"
                                                 >
                                                     {column.title}
                                                 </TableHead>
                                             ))}
                                             {data.table.actions && (
-                                                <TableHead className="py-3 px-4 text-sm font-medium text-muted-foreground">
+                                                <TableHead className="py-3 px-4 text-sm font-medium text-muted-foreground md:text-nowrap">
                                                     {data.table.actions.title}
                                                 </TableHead>
                                             )}


### PR DESCRIPTION
Tables with recent cases and notifications aren't aligned.

![image](https://github.com/user-attachments/assets/d2583a70-8ea5-47ad-a2a8-5db7e9a743fa)
