### PR TITLE
Docs/add changeset instructions

### DIFF
--- a/.changeset/ten-roses-tell.md
+++ b/.changeset/ten-roses-tell.md
@@ -1,0 +1,5 @@
+---
+'@o2s/docs': minor
+---
+
+Added detailed instructions for using changeset to the CONTRIBUTING.md file. This will help contributors understand when and how to create changesets before submitting their pull requests, improving the project's release management process and ensuring all changes are properly documented.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ If commits are related to specific apps you can structure the massage like so: `
 Before submitting your PR, create a changeset to document your changes:
 
 ```
-npm changeset # or pnpm changeset / yarn changeset
+npm run changeset 
 ```
 
 This will prompt you to:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,11 @@ We welcome contributions from everyone in the community and appreciate your help
 ## 📌 Where to Start
 
 1. **Read the [Documentation](https://www.openselfservice.com/docs/).**
+
     - This will help you understand the project structure, architecture, and how O2S works.
 
 2. **Check for Open Issues.**
+
     - Browse the **[GitHub Issues](https://github.com/o2sdev/openselfservice/issues)** to find something you’d like to work on.
 
 3. **Join the Discussion.**
@@ -52,9 +54,26 @@ feat: add new authentication flow
 fix: resolve dashboard layout bug
 docs: update API reference
 ```
+
 If commits are related to specific apps you can structure the massage like so: `fix(frontend): fixing styles for Y component`
 
-### 5. Push and Open a Pull Request (PR)
+### 5. Create a Changeset
+
+Before submitting your PR, create a changeset to document your changes:
+
+```
+npm changeset # or pnpm changeset / yarn changeset
+```
+
+This will prompt you to:
+
+- Select the packages you've modified
+- Choose the type of change (major, minor, patch)
+- Write a brief description of your changes
+
+For more information, see the [official Changeset documentation](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md).
+
+### 6. Push and Open a Pull Request (PR)
 
 ```
 git push origin feature/your-feature-name
@@ -62,7 +81,7 @@ git push origin feature/your-feature-name
 
 Then, go to **[GitHub](https://github.com/o2sdev/openselfservice)** and open a **Pull Request (PR)**.
 
-### 6. Get a Review
+### 7. Get a Review
 
 - Your PR will be reviewed by someone from our team.
 - If changes are requested, address them and push new commits to your branch.
@@ -94,6 +113,7 @@ Once your PR is merged, we will add your name to the **Contributors list** in th
 ## 📩 Questions?
 
 For general questions, feel free to:
+
 - Open a **[GitHub Discussion](https://github.com/o2sdev/openselfservice/discussions)**.
 - Reach out on **[Twitter/X](https://twitter.com/openselfservice)** or **[contact@openselfservice.com](mailto:contact@openselfservice.com)**.
 


### PR DESCRIPTION
**What does this PR do?**
- [x] Add changeset instructions to CONTRIBUTING.md

**Related Ticket(s)**
- #76

**Key Changes**
- Added a new section "Create a Changeset" to the contribution workflow in CONTRIBUTING.md
- Included step-by-step instructions explaining how to run the changeset command and what information to provide
- Added a link to the official Changeset documentation for further reference
- Renumbered subsequent steps to maintain document flow

**How to test**
1. Review the updated CONTRIBUTING.md file to verify the changeset instructions are clear and accurate
2. Try following the instructions to create a changeset for this PR:
   - Run `npm run changeset` 
   - Select the relevant package(s)
   - Choose "patch" as the change type
   - Add a description about the documentation change