### PR TITLE
feat: implemented user role-based access to pages and articles

### DIFF
--- a/.changeset/cold-breads-move.md
+++ b/.changeset/cold-breads-move.md
@@ -1,0 +1,5 @@
+---
+'@o2s/framework': minor
+---
+
+refactored user roles to allow more than one role on organization level and added permission fields on `Page` and `Article` models to allow displaying them based on user roles

--- a/.changeset/lazy-years-throw.md
+++ b/.changeset/lazy-years-throw.md
@@ -1,0 +1,6 @@
+---
+'@o2s/api-harmonization': minor
+'@o2s/frontend': minor
+---
+
+implemented user role-based access to pages and articles

--- a/.changeset/sixty-ants-stop.md
+++ b/.changeset/sixty-ants-stop.md
@@ -1,0 +1,7 @@
+---
+'@o2s/integrations.strapi-cms': minor
+'@o2s/integrations.algolia': minor
+'@o2s/integrations.mocked': minor
+---
+
+adjusted `Page` and `Article` models to conform with new user-based permission model

--- a/apps/api-harmonization/src/modules/page/page.model.ts
+++ b/apps/api-harmonization/src/modules/page/page.model.ts
@@ -49,7 +49,6 @@ export class NotFound {
 export class Metadata {
     seo!: Models.SEO.Page;
     locales!: string[];
-    isProtected!: boolean;
 }
 
 export class Breadcrumb {

--- a/apps/api-harmonization/src/modules/page/page.module.ts
+++ b/apps/api-harmonization/src/modules/page/page.module.ts
@@ -2,7 +2,7 @@ import { DynamicModule, Module } from '@nestjs/common';
 
 import * as Framework from '@o2s/framework/modules';
 
-import { Articles, CMS } from '../../models';
+import { Articles, Auth, CMS } from '../../models';
 
 import { PageController } from './page.controller';
 import { PageService } from './page.service';
@@ -21,6 +21,10 @@ export class PageModule {
                 {
                     provide: Articles.Service,
                     useExisting: Framework.Articles.Service,
+                },
+                {
+                    provide: Auth.Service,
+                    useExisting: Framework.Auth.Service,
                 },
             ],
             controllers: [PageController],

--- a/apps/api-harmonization/src/modules/page/page.service.ts
+++ b/apps/api-harmonization/src/modules/page/page.service.ts
@@ -4,8 +4,9 @@ import { Observable, concatMap, forkJoin, map, of, switchMap } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 import { AppHeaders } from '@o2s/api-harmonization/utils/headers';
+import { checkPermissions } from '@o2s/api-harmonization/utils/permissions';
 
-import { Articles, CMS } from '../../models';
+import { Articles, Auth, CMS } from '../../models';
 
 import { mapArticle, mapInit, mapPage } from './page.mapper';
 import { Init, NotFound, Page } from './page.model';
@@ -19,6 +20,7 @@ export class PageService {
         private readonly config: ConfigService,
         private readonly cmsService: CMS.Service,
         private readonly articlesService: Articles.Service,
+        private readonly authService: Auth.Service,
     ) {
         this.SUPPORTED_LOCALES = this.config.get('SUPPORTED_LOCALES').split(',') as string[];
     }
@@ -46,6 +48,8 @@ export class PageService {
     }
 
     getInit(query: GetInitQuery, headers: AppHeaders): Observable<Init> {
+        const userRoles = this.authService.extractUserRoles(headers['authorization']);
+
         return this.cmsService.getAppConfig({ referrer: query.referrer, locale: headers['x-locale'] }).pipe(
             switchMap((appConfig) => {
                 const header = this.cmsService.getHeader({
@@ -60,7 +64,7 @@ export class PageService {
 
                 return forkJoin([header, footer]).pipe(
                     map(([header, footer]) => {
-                        return mapInit(appConfig.locales, header, footer, appConfig.labels);
+                        return mapInit(appConfig.locales, header, footer, appConfig.labels, userRoles);
                     }),
                 );
             }),
@@ -70,6 +74,8 @@ export class PageService {
     getPage(query: GetPageQuery, headers: AppHeaders): Observable<Page | NotFound> {
         const page = this.cmsService.getPage({ slug: query.slug, locale: headers['x-locale'] });
 
+        const userRoles = this.authService.extractUserRoles(headers['authorization']);
+
         return forkJoin([page]).pipe(
             concatMap(([page]) => {
                 if (!page) {
@@ -77,15 +83,10 @@ export class PageService {
                         .getArticle({ slug: query.slug, locale: headers['x-locale'] })
                         .pipe(concatMap((article) => this.processArticle(article, query, headers)));
                 }
+
+                checkPermissions(page.permissions, userRoles);
+
                 return this.processPage(page, query, headers);
-            }),
-            catchError(() => {
-                return this.articlesService
-                    .getArticle({ slug: query.slug, locale: headers['x-locale'] })
-                    .pipe(concatMap((article) => this.processArticle(article, query, headers)));
-            }),
-            catchError(() => {
-                throw new NotFoundException();
             }),
         );
     }
@@ -107,6 +108,10 @@ export class PageService {
         if (!article.category) {
             throw new NotFoundException();
         }
+
+        const userRoles = this.authService.extractUserRoles(headers['authorization']);
+
+        checkPermissions(article.permissions, userRoles);
 
         const category = this.articlesService.getCategory({ id: article.category.id, locale: headers['x-locale'] });
 

--- a/apps/api-harmonization/src/utils/permissions.ts
+++ b/apps/api-harmonization/src/utils/permissions.ts
@@ -1,0 +1,13 @@
+import { UnauthorizedException } from '@nestjs/common';
+
+import { Auth } from '@o2s/framework/modules';
+
+export const checkPermissions = (permissions?: Auth.Constants.Roles[], userRoles?: Auth.Constants.Roles[]) => {
+    if (permissions?.length && userRoles && !permissions?.some((role) => userRoles.includes(role))) {
+        throw new UnauthorizedException();
+    }
+};
+
+export const getHasAccess = (permissions?: Auth.Constants.Roles[], userRoles?: Auth.Constants.Roles[]) => {
+    return !(permissions?.length && userRoles && !permissions?.some((role) => userRoles.includes(role)));
+};

--- a/packages/framework/src/modules/articles/articles.model.ts
+++ b/packages/framework/src/modules/articles/articles.model.ts
@@ -1,3 +1,5 @@
+import { Auth } from '@o2s/framework/modules';
+
 import { Media, Pagination } from '@/utils/models';
 
 export class Category {
@@ -40,7 +42,7 @@ export class Article {
     };
     author?: Author;
     sections!: ArticleSection[];
-    isProtected!: boolean;
+    permissions?: Auth.Constants.Roles[];
 }
 
 export type ArticleSection = ArticleSectionText | ArticleSectionImage;

--- a/packages/framework/src/modules/auth/auth.constants.ts
+++ b/packages/framework/src/modules/auth/auth.constants.ts
@@ -1,6 +1,6 @@
 export enum Roles {
-    ADMIN = 'selfservice_admin',
     USER = 'selfservice_user',
+    ADMIN = 'selfservice_admin',
 }
 
 export enum RoleMatchingMode {

--- a/packages/framework/src/modules/auth/auth.service.ts
+++ b/packages/framework/src/modules/auth/auth.service.ts
@@ -7,5 +7,5 @@ export abstract class AuthService {
 
     abstract decodeAuthorizationToken(token: string): Auth.Model.Jwt;
     abstract getCustomerId(token: string): string | undefined;
-    abstract extractUserRoles(token: string | Auth.Model.Jwt): string[];
+    abstract extractUserRoles(token?: string | Auth.Model.Jwt): Auth.Constants.Roles[];
 }

--- a/packages/framework/src/modules/cms/models/page.model.ts
+++ b/packages/framework/src/modules/cms/models/page.model.ts
@@ -1,4 +1,4 @@
-import { Models } from '@o2s/framework/modules';
+import { Auth, Models } from '@o2s/framework/modules';
 
 export class Page {
     id!: string;
@@ -21,7 +21,7 @@ export class Page {
             };
         };
     };
-    isProtected!: boolean;
+    permissions?: Auth.Constants.Roles[];
 }
 
 export abstract class Template {

--- a/packages/framework/src/utils/models/navigation.ts
+++ b/packages/framework/src/utils/models/navigation.ts
@@ -1,7 +1,10 @@
+import { Auth } from '@o2s/framework/modules';
+
 export class NavigationGroup {
     __typename!: 'NavigationGroup';
     title!: string;
     items!: (NavigationItem | NavigationGroup)[];
+    permissions?: Auth.Constants.Roles[];
 }
 
 export class NavigationItem {
@@ -9,4 +12,5 @@ export class NavigationItem {
     url?: string;
     label!: string;
     description?: string;
+    permissions?: Auth.Constants.Roles[];
 }

--- a/packages/framework/src/utils/models/roles.ts
+++ b/packages/framework/src/utils/models/roles.ts
@@ -1,6 +1,8 @@
+import { Auth } from '@o2s/framework/modules';
+
 import { Customer } from '@/utils/models/customer';
 
 export class UserCustomerRole {
-    role!: string;
+    roles!: Auth.Constants.Roles[];
     customer?: Customer;
 }

--- a/packages/integrations/algolia/src/modules/search/mappers/articles.mapper.ts
+++ b/packages/integrations/algolia/src/modules/search/mappers/articles.mapper.ts
@@ -9,7 +9,7 @@ export const mapArticlesFromSearch = (
         (hit): Articles.Model.Article => ({
             id: hit.documentId,
             slug: hit.slug,
-            isProtected: false,
+            permissions: [],
             createdAt: hit.updatedAt,
             updatedAt: hit.updatedAt,
             title: hit.SEO.title,

--- a/packages/integrations/mocked/src/auth/auth.jwt.ts
+++ b/packages/integrations/mocked/src/auth/auth.jwt.ts
@@ -54,7 +54,7 @@ async function updateCustomerToken(
         if (customer) {
             token.customer = {
                 id: customer.id,
-                roles: customer?.roles?.map((role) => role.role) ?? [],
+                roles: customer?.roles?.map((role) => role.roles).flat() ?? [],
                 name: customer?.name ?? '',
             };
         }

--- a/packages/integrations/mocked/src/integration.ts
+++ b/packages/integrations/mocked/src/integration.ts
@@ -21,6 +21,7 @@ export const Config: Partial<ApiConfig['integrations']> = {
     cms: {
         name: 'mocked',
         service: CmsService,
+        imports: [Auth.Module],
     },
     tickets: {
         name: 'mocked',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article1.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article1.content.mocks.ts
@@ -4,7 +4,7 @@ export const MOCK_ARTICLE1_EN: Articles.Model.Article[] = [
     {
         id: 'art-002',
         slug: '/help-and-support/maintenance/powerpro-tool-maintenance-guide',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-06-10T10:15:00Z',
         updatedAt: '2023-07-20T16:30:00Z',
         title: 'PowerPro Tool Maintenance Guide',
@@ -232,7 +232,7 @@ export const MOCK_ARTICLE1_DE: Articles.Model.Article[] = [
     {
         id: 'art-002',
         slug: '/hilfe-und-support/wartung/powerpro-werkzeug-wartungsanleitung',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-06-10T10:15:00Z',
         updatedAt: '2023-07-20T16:30:00Z',
         title: 'PowerPro-Werkzeug-Wartungsanleitung',
@@ -460,7 +460,7 @@ export const MOCK_ARTICLE1_PL: Articles.Model.Article[] = [
     {
         id: 'art-002',
         slug: '/pomoc-i-wsparcie/konserwacja/przewodnik-konserwacji-narzedzi-powerpro',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-06-10T10:15:00Z',
         updatedAt: '2023-07-20T16:30:00Z',
         title: 'Przewodnik konserwacji narzędzi PowerPro',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article10.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article10.content.mocks.ts
@@ -412,7 +412,7 @@ export const MOCK_ARTICLE10_EN: Articles.Model.Article[] = [
     {
         id: 'art-010',
         slug: '/help-and-support/troubleshooting/troubleshooting-guide-for-powerpro-tools',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-03-20T10:15:00Z',
         updatedAt: '2023-06-05T16:30:00Z',
         title: 'Troubleshooting Guide for PowerPro Tools',
@@ -477,7 +477,7 @@ export const MOCK_ARTICLE10_DE: Articles.Model.Article[] = [
     {
         id: 'art-010',
         slug: '/hilfe-und-support/fehlerbehebung/fehlerbehebung-fur-powerpro-werkzeuge',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-03-20T10:15:00Z',
         updatedAt: '2023-06-05T16:30:00Z',
         title: 'Fehlerbehebung für PowerPro-Werkzeuge',
@@ -543,7 +543,7 @@ export const MOCK_ARTICLE10_PL: Articles.Model.Article[] = [
     {
         id: 'art-010',
         slug: '/pomoc-i-wsparcie/rozwiazywanie-problemow/przewodnik-rozwiazywania-problemow-z-narzedziami-powerpro',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-03-20T10:15:00Z',
         updatedAt: '2023-06-05T16:30:00Z',
         title: 'Przewodnik rozwiązywania problemów z narzędziami PowerPro',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article11.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article11.content.mocks.ts
@@ -4,7 +4,7 @@ export const MOCK_ARTICLE11_EN: Articles.Model.Article[] = [
     {
         id: 'art-011',
         slug: '/help-and-support/warranty-and-repair/powerpro-tool-certification-program',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-09-12T14:50:00Z',
         updatedAt: '2023-09-12T14:50:00Z',
         title: 'PowerPro Tool Certification Program',
@@ -68,7 +68,7 @@ export const MOCK_ARTICLE11_EN: Articles.Model.Article[] = [
     {
         id: 'art-015',
         slug: '/help-and-support/warranty/expedited-repair-service-options',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-07-30T12:10:00Z',
         updatedAt: '2023-07-30T12:10:00Z',
         title: 'Expedited Repair Service Options',
@@ -111,7 +111,7 @@ export const MOCK_ARTICLE11_EN: Articles.Model.Article[] = [
     {
         id: 'art-017',
         slug: '/help-and-support/warranty/repair-tracking-system-benefits',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-01-15T13:30:00Z',
         updatedAt: '2023-04-22T15:45:00Z',
         title: "Benefits of PowerPro's Repair Tracking System",
@@ -169,7 +169,7 @@ export const MOCK_ARTICLE11_DE: Articles.Model.Article[] = [
     {
         id: 'art-011',
         slug: '/hilfe-und-support/garantie/powerpro-werkzeug-zertifizierungsprogramm',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-09-12T14:50:00Z',
         updatedAt: '2023-09-12T14:50:00Z',
         title: 'PowerPro-Werkzeug-Zertifizierungsprogramm',
@@ -236,7 +236,7 @@ export const MOCK_ARTICLE11_PL: Articles.Model.Article[] = [
     {
         id: 'art-011',
         slug: '/pomoc-i-wsparcie/gwarancja/program-certyfikacji-narzedzi-powerpro',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-09-12T14:50:00Z',
         updatedAt: '2023-09-12T14:50:00Z',
         title: 'Program certyfikacji narzędzi PowerPro',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article12.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article12.content.mocks.ts
@@ -4,7 +4,7 @@ export const MOCK_ARTICLE12_EN: Articles.Model.Article[] = [
     {
         id: 'art-004',
         slug: '/help-and-support/warranty-and-repair/understanding-powerpro-warranty',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-06-24T10:15:00Z',
         updatedAt: '2023-08-15T16:40:00Z',
         title: 'Understanding Your PowerPro Warranty',
@@ -67,7 +67,7 @@ export const MOCK_ARTICLE12_EN: Articles.Model.Article[] = [
     {
         id: 'art-009',
         slug: '/help-and-support/warranty/repair-or-replace-decision-guide',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-05-19T09:10:00Z',
         updatedAt: '2023-06-30T14:25:00Z',
         title: 'Repair or Replace? Making the Right Decision',
@@ -133,7 +133,7 @@ export const MOCK_ARTICLE12_DE: Articles.Model.Article[] = [
     {
         id: 'art-004',
         slug: '/hilfe-und-support/garantie/powerpro-garantie-verstehen',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-06-24T10:15:00Z',
         updatedAt: '2023-08-15T16:40:00Z',
         title: 'Ihre PowerPro-Garantie verstehen',
@@ -199,7 +199,7 @@ export const MOCK_ARTICLE12_PL: Articles.Model.Article[] = [
     {
         id: 'art-004',
         slug: '/pomoc-i-wsparcie/gwarancja/rozumienie-gwarancji-powerpro',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-06-24T10:15:00Z',
         updatedAt: '2023-08-15T16:40:00Z',
         title: 'Zrozumienie gwarancji PowerPro',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article13.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article13.content.mocks.ts
@@ -4,7 +4,7 @@ export const MOCK_ARTICLE13_EN: Articles.Model.Article[] = [
     {
         id: 'art-012',
         slug: '/help-and-support/warranty-and-repair/preventive-maintenance-guide',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-08-20T11:30:00Z',
         updatedAt: '2023-09-05T15:20:00Z',
         title: 'Preventive Maintenance Guide for PowerPro Tools',
@@ -70,7 +70,7 @@ export const MOCK_ARTICLE13_DE: Articles.Model.Article[] = [
     {
         id: 'art-012',
         slug: '/hilfe-und-support/garantie/vorbeugende-wartung-leitfaden',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-08-20T11:30:00Z',
         updatedAt: '2023-09-05T15:20:00Z',
         title: 'Leitfaden zur vorbeugenden Wartung von PowerPro-Werkzeugen',
@@ -137,7 +137,7 @@ export const MOCK_ARTICLE13_PL: Articles.Model.Article[] = [
     {
         id: 'art-012',
         slug: '/pomoc-i-wsparcie/gwarancja/przewodnik-po-konserwacji-zapobiegawczej',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-08-20T11:30:00Z',
         updatedAt: '2023-09-05T15:20:00Z',
         title: 'Przewodnik po konserwacji zapobiegawczej narzędzi PowerPro',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article2.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article2.content.mocks.ts
@@ -4,7 +4,7 @@ export const MOCK_ARTICLE2_EN: Articles.Model.Article[] = [
     {
         id: 'art-003',
         slug: '/help-and-support/safety/powerpro-tool-safety-guidelines',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-07-15T09:45:00Z',
         updatedAt: '2023-08-25T13:20:00Z',
         title: 'PowerPro Tool Safety Guidelines',
@@ -242,7 +242,7 @@ export const MOCK_ARTICLE2_DE: Articles.Model.Article[] = [
     {
         id: 'art-003',
         slug: '/hilfe-und-support/sicherheit/powerpro-werkzeug-sicherheitsrichtlinien',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-07-15T09:45:00Z',
         updatedAt: '2023-08-25T13:20:00Z',
         title: 'PowerPro-Werkzeug-Sicherheitsrichtlinien',
@@ -480,7 +480,7 @@ export const MOCK_ARTICLE2_PL: Articles.Model.Article[] = [
     {
         id: 'art-003',
         slug: '/pomoc-i-wsparcie/bezpieczenstwo/wytyczne-bezpieczenstwa-narzedzi-powerpro',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-07-15T09:45:00Z',
         updatedAt: '2023-08-25T13:20:00Z',
         title: 'Wytyczne bezpieczeństwa narzędzi PowerPro',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article3.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article3.content.mocks.ts
@@ -4,7 +4,7 @@ export const MOCK_ARTICLE3_EN: Articles.Model.Article[] = [
     {
         id: 'art-004',
         slug: '/help-and-support/accessories/essential-powerpro-tool-accessories',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-08-20T11:30:00Z',
         updatedAt: '2023-09-30T15:45:00Z',
         title: 'Essential PowerPro Tool Accessories',
@@ -313,7 +313,7 @@ export const MOCK_ARTICLE3_DE: Articles.Model.Article[] = [
     {
         id: 'art-004',
         slug: '/hilfe-und-support/zubehor/wesentliches-powerpro-werkzeugzubehor',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-08-20T11:30:00Z',
         updatedAt: '2023-09-30T15:45:00Z',
         title: 'Wesentliches PowerPro-Werkzeugzubehör',
@@ -622,7 +622,7 @@ export const MOCK_ARTICLE3_PL: Articles.Model.Article[] = [
     {
         id: 'art-004',
         slug: '/pomoc-i-wsparcie/akcesoria/niezbedne-akcesoria-do-narzedzi-powerpro',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-08-20T11:30:00Z',
         updatedAt: '2023-09-30T15:45:00Z',
         title: 'Niezbędne akcesoria do narzędzi PowerPro',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article4.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article4.content.mocks.ts
@@ -520,7 +520,7 @@ export const MOCK_ARTICLE4_EN: Articles.Model.Article[] = [
     {
         id: 'art-001',
         slug: '/help-and-support/warranty-and-repair/managing-your-powerpro-tools-online',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-05-12T08:30:00Z',
         updatedAt: '2023-06-15T14:25:00Z',
         title: 'Managing Your PowerPro Tools Online',
@@ -586,7 +586,7 @@ export const MOCK_ARTICLE4_DE: Articles.Model.Article[] = [
     {
         id: 'art-001',
         slug: '/hilfe-und-support/garantie-und-reparatur/verwalten-ihrer-powerpro-werkzeuge-online',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-05-12T08:30:00Z',
         updatedAt: '2023-06-15T14:25:00Z',
         title: 'Verwalten Ihrer PowerPro-Werkzeuge online',
@@ -652,7 +652,7 @@ export const MOCK_ARTICLE4_PL: Articles.Model.Article[] = [
     {
         id: 'art-001',
         slug: '/pomoc-i-wsparcie/gwarancja-i-naprawa/zarzadzanie-narzedziami-powerpro-online',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-05-12T08:30:00Z',
         updatedAt: '2023-06-15T14:25:00Z',
         title: 'Zarządzanie narzędziami PowerPro online',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article5.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article5.content.mocks.ts
@@ -382,7 +382,7 @@ export const MOCK_ARTICLE5_EN: Articles.Model.Article[] = [
     {
         id: 'art-005',
         slug: '/help-and-support/safety/safe-usage-of-powerpro-tools',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-05-12T08:30:00Z',
         updatedAt: '2023-06-15T14:25:00Z',
         title: 'Safe Usage of PowerPro Tools',
@@ -447,7 +447,7 @@ export const MOCK_ARTICLE5_DE: Articles.Model.Article[] = [
     {
         id: 'art-005',
         slug: '/hilfe-und-support/sicherheit/sicheres-verwenden-von-powerpro-werkzeugen',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-05-12T08:30:00Z',
         updatedAt: '2023-06-15T14:25:00Z',
         title: 'Sicheres Verwenden von PowerPro-Werkzeugen',
@@ -512,7 +512,7 @@ export const MOCK_ARTICLE5_PL: Articles.Model.Article[] = [
     {
         id: 'art-005',
         slug: '/pomoc-i-wsparcie/bezpieczenstwo/bezpieczne-uzytkowanie-narzedzi-powerpro',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-05-12T08:30:00Z',
         updatedAt: '2023-06-15T14:25:00Z',
         title: 'Bezpieczne użytkowanie narzędzi PowerPro',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article6.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article6.content.mocks.ts
@@ -502,7 +502,7 @@ export const MOCK_ARTICLE6_EN: Articles.Model.Article[] = [
     {
         id: 'art-006',
         slug: '/help-and-support/troubleshooting/common-powerpro-tool-issues',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-05-12T08:30:00Z',
         updatedAt: '2023-06-15T14:25:00Z',
         title: 'Troubleshooting Common PowerPro Tool Issues',
@@ -567,7 +567,7 @@ export const MOCK_ARTICLE6_DE: Articles.Model.Article[] = [
     {
         id: 'art-006',
         slug: '/hilfe-und-support/fehlerbehebung/haufige-powerpro-werkzeugprobleme',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-05-12T08:30:00Z',
         updatedAt: '2023-06-15T14:25:00Z',
         title: 'Behebung häufiger PowerPro-Werkzeugprobleme',
@@ -633,7 +633,7 @@ export const MOCK_ARTICLE6_PL: Articles.Model.Article[] = [
     {
         id: 'art-006',
         slug: '/pomoc-i-wsparcie/rozwiazywanie-problemow/typowe-problemy-z-narzedziami-powerpro',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-05-12T08:30:00Z',
         updatedAt: '2023-06-15T14:25:00Z',
         title: 'Rozwiązywanie typowych problemów z narzędziami PowerPro',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article7.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article7.content.mocks.ts
@@ -394,7 +394,7 @@ export const MOCK_ARTICLE7_EN: Articles.Model.Article[] = [
     {
         id: 'art-007',
         slug: '/help-and-support/registration/step-by-step-guide-to-tool-registration',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-01-30T11:20:00Z',
         updatedAt: '2023-05-22T09:10:00Z',
         title: 'Step-by-Step Guide to Tool Registration',
@@ -459,7 +459,7 @@ export const MOCK_ARTICLE7_DE: Articles.Model.Article[] = [
     {
         id: 'art-007',
         slug: '/hilfe-und-support/registrierung/schritt-fur-schritt-anleitung-zur-werkzeugregistrierung',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-01-30T11:20:00Z',
         updatedAt: '2023-05-22T09:10:00Z',
         title: 'Schritt-für-Schritt-Anleitung zur Werkzeugregistrierung',
@@ -525,7 +525,7 @@ export const MOCK_ARTICLE7_PL: Articles.Model.Article[] = [
     {
         id: 'art-007',
         slug: '/pomoc-i-wsparcie/rejestracja/przewodnik-krok-po-kroku-rejestracja-narzedzi',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-01-30T11:20:00Z',
         updatedAt: '2023-05-22T09:10:00Z',
         title: 'Przewodnik krok po kroku: Rejestracja narzędzi',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article8.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article8.content.mocks.ts
@@ -412,7 +412,7 @@ export const MOCK_ARTICLE8_EN: Articles.Model.Article[] = [
     {
         id: 'art-008',
         slug: '/help-and-support/troubleshooting/troubleshooting-common-powerpro-tool-issues',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-02-15T09:30:00Z',
         updatedAt: '2023-06-10T14:20:00Z',
         title: 'Troubleshooting Common PowerPro Tool Issues',
@@ -478,7 +478,7 @@ export const MOCK_ARTICLE8_DE: Articles.Model.Article[] = [
     {
         id: 'art-008',
         slug: '/hilfe-und-support/fehlerbehebung/fehlerbehebung-bei-haufigen-powerpro-werkzeugproblemen',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-02-15T09:30:00Z',
         updatedAt: '2023-06-10T14:20:00Z',
         title: 'Fehlerbehebung bei häufigen PowerPro-Werkzeugproblemen',
@@ -544,7 +544,7 @@ export const MOCK_ARTICLE8_PL: Articles.Model.Article[] = [
     {
         id: 'art-008',
         slug: '/pomoc-i-wsparcie/rozwiązywanie-problemow/rozwiązywanie-typowych-problemow-z-narzedziami-powerpro',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-02-15T09:30:00Z',
         updatedAt: '2023-06-10T14:20:00Z',
         title: 'Rozwiązywanie typowych problemów z narzędziami PowerPro',

--- a/packages/integrations/mocked/src/modules/articles/mocks/article9.content.mocks.ts
+++ b/packages/integrations/mocked/src/modules/articles/mocks/article9.content.mocks.ts
@@ -592,7 +592,7 @@ export const MOCK_ARTICLE9_EN: Articles.Model.Article[] = [
     {
         id: 'art-009',
         slug: '/help-and-support/safety/safety-and-maintenance-guide-for-powerpro-tools',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-03-20T10:15:00Z',
         updatedAt: '2023-06-05T16:30:00Z',
         title: 'Safety and Maintenance Guide for PowerPro Tools',
@@ -657,7 +657,7 @@ export const MOCK_ARTICLE9_DE: Articles.Model.Article[] = [
     {
         id: 'art-009',
         slug: '/hilfe-und-support/sicherheit/sicherheits-und-wartungsleitfaden-fur-powerpro-werkzeuge',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-03-20T10:15:00Z',
         updatedAt: '2023-06-05T16:30:00Z',
         title: 'Sicherheits- und Wartungsleitfaden für PowerPro-Werkzeuge',
@@ -723,7 +723,7 @@ export const MOCK_ARTICLE9_PL: Articles.Model.Article[] = [
     {
         id: 'art-009',
         slug: '/pomoc-i-wsparcie/bezpieczenstwo/przewodnik-bezpieczenstwa-i-konserwacji-narzedzi-powerpro',
-        isProtected: false,
+        permissions: [],
         createdAt: '2023-03-20T10:15:00Z',
         updatedAt: '2023-06-05T16:30:00Z',
         title: 'Przewodnik bezpieczeństwa i konserwacji narzędzi PowerPro',

--- a/packages/integrations/mocked/src/modules/auth/auth.service.ts
+++ b/packages/integrations/mocked/src/modules/auth/auth.service.ts
@@ -23,7 +23,11 @@ export class AuthService implements Auth.Service {
         return decodedToken.customer?.id;
     }
 
-    extractUserRoles(token: string | Jwt): string[] {
+    extractUserRoles(token?: string | Jwt): Auth.Constants.Roles[] {
+        if (!token) {
+            return [];
+        }
+
         let decodedToken: Jwt;
         if (typeof token === 'string') {
             decodedToken = this.decodeAuthorizationToken(token);
@@ -41,6 +45,6 @@ export class AuthService implements Auth.Service {
             userRoles.push(...decodedToken.customer.roles);
         }
 
-        return userRoles;
+        return userRoles as Auth.Constants.Roles[];
     }
 }

--- a/packages/integrations/mocked/src/modules/cms/mappers/cms.footer.mapper.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/cms.footer.mapper.ts
@@ -68,24 +68,48 @@ const MOCK_FOOTER_PL: CMS.Model.Footer.Footer = {
             __typename: 'NavigationGroup',
             title: 'Polityka Prywatności',
             items: [
-                { label: 'Polityka Prywatności 1', url: '/powiadomienia', __typename: 'NavigationItem' },
-                { label: 'Polityka Prywatności 2', url: '/rachunki', __typename: 'NavigationItem' },
+                {
+                    label: 'Polityka Prywatności 1',
+                    url: 'https://hycom.digital/privacy-policy',
+                    __typename: 'NavigationItem',
+                },
+                {
+                    label: 'Polityka Prywatności 2',
+                    url: 'https://hycom.digital/privacy-policy',
+                    __typename: 'NavigationItem',
+                },
             ],
         },
         {
             __typename: 'NavigationGroup',
             title: 'Warunki Korzystania',
             items: [
-                { label: 'Warunki Korzystania 1', url: '/powiadomienia', __typename: 'NavigationItem' },
-                { label: 'Warunki Korzystania 2', url: '/rachunki', __typename: 'NavigationItem' },
+                {
+                    label: 'Warunki Korzystania 1',
+                    url: 'https://hycom.digital/terms-and-conditions',
+                    __typename: 'NavigationItem',
+                },
+                {
+                    label: 'Warunki Korzystania 2',
+                    url: 'https://hycom.digital/terms-and-conditions',
+                    __typename: 'NavigationItem',
+                },
             ],
         },
         {
             __typename: 'NavigationGroup',
             title: 'Ustawienia Plików Cookie',
             items: [
-                { label: 'Ustawienia Plików Cookie 1', url: '/powiadomienia', __typename: 'NavigationItem' },
-                { label: 'Ustawienia Plików Cookie 2', url: '/rachunki', __typename: 'NavigationItem' },
+                {
+                    label: 'Ustawienia Plików Cookie 1',
+                    url: '/',
+                    __typename: 'NavigationItem',
+                },
+                {
+                    label: 'Ustawienia Plików Cookie 2',
+                    url: '/',
+                    __typename: 'NavigationItem',
+                },
             ],
         },
     ],
@@ -106,24 +130,40 @@ const MOCK_FOOTER_DE: CMS.Model.Footer.Footer = {
             __typename: 'NavigationGroup',
             title: 'Datenschutzrichtlinie',
             items: [
-                { label: 'Datenschutzrichtlinie 1', url: '/benachrichtigungen', __typename: 'NavigationItem' },
-                { label: 'Datenschutzrichtlinie 2', url: '/invoices', __typename: 'NavigationItem' },
+                {
+                    label: 'Datenschutzrichtlinie 1',
+                    url: 'https://hycom.digital/privacy-policy',
+                    __typename: 'NavigationItem',
+                },
+                {
+                    label: 'Datenschutzrichtlinie 2',
+                    url: 'https://hycom.digital/privacy-policy',
+                    __typename: 'NavigationItem',
+                },
             ],
         },
         {
             __typename: 'NavigationGroup',
             title: 'Nutzungsbedingungen',
             items: [
-                { label: 'Nutzungsbedingungen 1', url: '/benachrichtigungen', __typename: 'NavigationItem' },
-                { label: 'Nutzungsbedingungen 2', url: '/invoices', __typename: 'NavigationItem' },
+                {
+                    label: 'Nutzungsbedingungen 1',
+                    url: 'https://hycom.digital/terms-and-conditions',
+                    __typename: 'NavigationItem',
+                },
+                {
+                    label: 'Nutzungsbedingungen 2',
+                    url: 'https://hycom.digital/terms-and-conditions',
+                    __typename: 'NavigationItem',
+                },
             ],
         },
         {
             __typename: 'NavigationGroup',
             title: 'Cookie-Einstellungen',
             items: [
-                { label: 'Cookie-Einstellungen 1', url: '/benachrichtigungen', __typename: 'NavigationItem' },
-                { label: 'Cookie-Einstellungen 2', url: '/invoices', __typename: 'NavigationItem' },
+                { label: 'Cookie-Einstellungen 1', url: '/', __typename: 'NavigationItem' },
+                { label: 'Cookie-Einstellungen 2', url: '/', __typename: 'NavigationItem' },
             ],
         },
     ],

--- a/packages/integrations/mocked/src/modules/cms/mappers/cms.header.mapper.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/cms.header.mapper.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 const MOCK_HEADER_LOGON_EN: CMS.Model.Header.Header = {
     id: 'fqj6nnyk4irqq5b7rnc4ogsj',
@@ -27,31 +27,37 @@ const MOCK_HEADER_LOGON_EN: CMS.Model.Header.Header = {
                     __typename: 'NavigationItem',
                     label: 'Dashboard',
                     url: '/',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Cases',
                     url: '/cases',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Invoices',
                     url: '/invoices',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Notifications',
                     url: '/notifications',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Services',
                     url: '/services',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Orders',
                     url: '/orders',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
             ],
         },
@@ -103,31 +109,37 @@ const MOCK_HEADER_LOGON_DE: CMS.Model.Header.Header = {
                     __typename: 'NavigationItem',
                     label: 'Startseite',
                     url: '/',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Fälle',
                     url: '/faelle',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Rechnungen',
                     url: '/rechnungen',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Benachrichtigungen',
                     url: '/benachrichtigungen',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Dienstleistungen',
                     url: '/dienstleistungen',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Bestellungen',
                     url: '/bestellungen',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
             ],
         },
@@ -179,31 +191,37 @@ const MOCK_HEADER_LOGON_PL: CMS.Model.Header.Header = {
                     __typename: 'NavigationItem',
                     label: 'Strona główna',
                     url: '/',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Zgłoszenia',
                     url: '/zgloszenia',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Rachunki',
                     url: '/rachunki',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Powiadomienia',
                     url: '/powiadomienia',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Usługi',
                     url: '/uslugi',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
                 {
                     __typename: 'NavigationItem',
                     label: 'Zamówienia',
                     url: '/zamowienia',
+                    permissions: [Auth.Constants.Roles.USER],
                 },
             ],
         },
@@ -229,109 +247,8 @@ const MOCK_HEADER_LOGON_PL: CMS.Model.Header.Header = {
     },
 };
 
-const MOCK_HEADER_LOGOUT_EN: CMS.Model.Header.Header = {
-    id: 'lwvbmnaayn6w7xy5soicv1k2',
-    title: 'MOCK_HEADER_LOGOUT_EN',
-    logo: {
-        url: 'https://raw.githubusercontent.com/o2sdev/openselfservice/refs/heads/main/packages/integrations/mocked/public/images/logo.svg',
-        alt: 'Logo',
-        width: 92,
-        height: 24,
-    },
-    languageSwitcherLabel: 'Language',
-    mobileMenuLabel: {
-        open: 'Open menu',
-        close: 'Close Menu',
-    },
-    items: [
-        {
-            __typename: 'NavigationItem',
-            label: 'Customer Portal',
-            url: '/',
-        },
-        {
-            __typename: 'NavigationItem',
-            label: 'Help & Support',
-            url: '/cases',
-        },
-    ],
-    contextSwitcher: {
-        closeLabel: 'Close',
-        showContextSwitcher: false,
-    },
-};
-const MOCK_HEADER_LOGOUT_DE: CMS.Model.Header.Header = {
-    id: 'lwvbmnaayn6w7xy5soicv1k2',
-    title: 'MOCK_HEADER_LOGOUT_DE',
-    logo: {
-        url: 'https://raw.githubusercontent.com/o2sdev/openselfservice/refs/heads/main/packages/integrations/mocked/public/images/logo.svg',
-        alt: 'Logo',
-        width: 92,
-        height: 24,
-    },
-    languageSwitcherLabel: 'Sprache',
-    mobileMenuLabel: {
-        open: 'Menü öffnen',
-        close: 'Menü schließen',
-    },
-    items: [
-        {
-            __typename: 'NavigationItem',
-            label: 'Kunden Portal',
-            url: '/',
-        },
-        {
-            __typename: 'NavigationItem',
-            label: 'Hilfe & Unterstützung',
-            url: '/faelle',
-        },
-    ],
-    contextSwitcher: {
-        closeLabel: 'Schließen',
-        showContextSwitcher: false,
-    },
-};
-const MOCK_HEADER_LOGOUT_PL: CMS.Model.Header.Header = {
-    id: 'lwvbmnaayn6w7xy5soicv1k2',
-    title: 'MOCK_HEADER_LOGOUT_PL',
-    logo: {
-        url: 'https://raw.githubusercontent.com/o2sdev/openselfservice/refs/heads/main/packages/integrations/mocked/public/images/logo.svg',
-        alt: 'Logo',
-        width: 92,
-        height: 24,
-    },
-    languageSwitcherLabel: 'Język',
-    mobileMenuLabel: {
-        open: 'Otwórz menu',
-        close: 'Zamknij menu',
-    },
-    items: [
-        {
-            __typename: 'NavigationItem',
-            label: 'Portal Klienta',
-            url: '/',
-        },
-        {
-            __typename: 'NavigationItem',
-            label: 'Pomoc & Wsparcie',
-            url: '/zgloszenia',
-        },
-    ],
-    contextSwitcher: {
-        closeLabel: 'Zamknij',
-        showContextSwitcher: false,
-    },
-};
-
 export const mapHeader = (id: string, locale: string): CMS.Model.Header.Header => {
-    const headerList = [
-        MOCK_HEADER_LOGON_EN,
-        MOCK_HEADER_LOGON_DE,
-        MOCK_HEADER_LOGON_PL,
-        MOCK_HEADER_LOGOUT_EN,
-        MOCK_HEADER_LOGOUT_DE,
-        MOCK_HEADER_LOGOUT_PL,
-    ];
+    const headerList = [MOCK_HEADER_LOGON_EN, MOCK_HEADER_LOGON_DE, MOCK_HEADER_LOGON_PL];
 
     const header = headerList
         .filter((header) => header.title?.endsWith(locale.toUpperCase()))

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/category.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/category.page.ts
@@ -18,7 +18,7 @@ export const PAGE_WARRANTY_AND_REPAIR_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -52,7 +52,7 @@ export const PAGE_WARRANTY_AND_REPAIR_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -86,7 +86,7 @@ export const PAGE_WARRANTY_AND_REPAIR_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -122,7 +122,7 @@ export const PAGE_MAINTENANCE_EN: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -157,7 +157,7 @@ export const PAGE_MAINTENANCE_DE: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -192,7 +192,7 @@ export const PAGE_MAINTENANCE_PL: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -228,7 +228,7 @@ export const PAGE_SAFETY_EN: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -263,7 +263,7 @@ export const PAGE_SAFETY_DE: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -298,7 +298,7 @@ export const PAGE_SAFETY_PL: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -334,7 +334,7 @@ export const PAGE_ACCESSORIES_EN: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -369,7 +369,7 @@ export const PAGE_ACCESSORIES_DE: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -404,7 +404,7 @@ export const PAGE_ACCESSORIES_PL: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -440,7 +440,7 @@ export const PAGE_TROUBLESHOOTING_EN: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -475,7 +475,7 @@ export const PAGE_TROUBLESHOOTING_DE: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -510,7 +510,7 @@ export const PAGE_TROUBLESHOOTING_PL: CMS.Model.Page.Page = {
         },
     },
 
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/dashboard.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/dashboard.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_DASHBOARD_PL: CMS.Model.Page.Page = {
     slug: '/',
@@ -17,7 +17,7 @@ export const PAGE_DASHBOARD_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'TwoColumnTemplate',
@@ -72,7 +72,7 @@ export const PAGE_DASHBOARD_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'TwoColumnTemplate',
@@ -127,7 +127,7 @@ export const PAGE_DASHBOARD_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'TwoColumnTemplate',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/invoice-list.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/invoice-list.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_INVOICE_LIST_EN: CMS.Model.Page.Page = {
     id: '5',
@@ -17,7 +17,7 @@ export const PAGE_INVOICE_LIST_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'TwoColumnTemplate',
@@ -68,7 +68,7 @@ export const PAGE_INVOICE_LIST_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'TwoColumnTemplate',
@@ -119,7 +119,7 @@ export const PAGE_INVOICE_LIST_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'TwoColumnTemplate',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/knowledge-base.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/knowledge-base.page.ts
@@ -17,7 +17,7 @@ export const PAGE_HELP_AND_SUPPORT_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -67,7 +67,7 @@ export const PAGE_HELP_AND_SUPPORT_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -117,7 +117,7 @@ export const PAGE_HELP_AND_SUPPORT_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/notification-details.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/notification-details.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_NOTIFICATION_DETAILS_EN: CMS.Model.Page.Page = {
     id: '6',
@@ -17,7 +17,7 @@ export const PAGE_NOTIFICATION_DETAILS_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/notifications',
@@ -61,7 +61,7 @@ export const PAGE_NOTIFICATION_DETAILS_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/benachrichtigungen',
@@ -105,7 +105,7 @@ export const PAGE_NOTIFICATION_DETAILS_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/powiadomienia',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/notification-list.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/notification-list.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_NOTIFICATION_LIST_EN: CMS.Model.Page.Page = {
     id: '4',
@@ -17,7 +17,7 @@ export const PAGE_NOTIFICATION_LIST_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -55,7 +55,7 @@ export const PAGE_NOTIFICATION_LIST_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -93,7 +93,7 @@ export const PAGE_NOTIFICATION_LIST_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/order-details.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/order-details.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_ORDER_DETAILS_EN: CMS.Model.Page.Page = {
     id: '14',
@@ -17,7 +17,7 @@ export const PAGE_ORDER_DETAILS_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/orders',
@@ -57,7 +57,7 @@ export const PAGE_ORDER_DETAILS_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/bestellungen',
@@ -97,7 +97,7 @@ export const PAGE_ORDER_DETAILS_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/zamowienia',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/order-list.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/order-list.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_ORDER_LIST_EN: CMS.Model.Page.Page = {
     id: '13',
@@ -17,7 +17,7 @@ export const PAGE_ORDER_LIST_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -55,7 +55,7 @@ export const PAGE_ORDER_LIST_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -93,7 +93,7 @@ export const PAGE_ORDER_LIST_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/service-details.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/service-details.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_SERVICE_DETAILS_EN: CMS.Model.Page.Page = {
     id: '3',
@@ -17,7 +17,7 @@ export const PAGE_SERVICE_DETAILS_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/services',
@@ -65,7 +65,7 @@ export const PAGE_SERVICE_DETAILS_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/dienstleistungen',
@@ -113,7 +113,7 @@ export const PAGE_SERVICE_DETAILS_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/uslugi',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/service-list.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/service-list.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_SERVICE_LIST_EN: CMS.Model.Page.Page = {
     id: '8',
@@ -17,7 +17,7 @@ export const PAGE_SERVICE_LIST_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -59,7 +59,7 @@ export const PAGE_SERVICE_LIST_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -101,7 +101,7 @@ export const PAGE_SERVICE_LIST_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/surveyjs-forms.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/surveyjs-forms.page.ts
@@ -17,7 +17,7 @@ export const PAGE_CONTACT_US_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -51,7 +51,7 @@ export const PAGE_CONTACT_US_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -85,7 +85,7 @@ export const PAGE_CONTACT_US_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: false,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -119,7 +119,7 @@ export const PAGE_COMPLAINT_FORM_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -153,7 +153,7 @@ export const PAGE_COMPLAINT_FORM_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -187,7 +187,7 @@ export const PAGE_COMPLAINT_FORM_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -221,7 +221,7 @@ export const PAGE_REQUEST_DEVICE_MAINTENANCE_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -255,7 +255,7 @@ export const PAGE_REQUEST_DEVICE_MAINTENANCE_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',
@@ -289,7 +289,7 @@ export const PAGE_REQUEST_DEVICE_MAINTENANCE_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [],
     hasOwnTitle: false,
     template: {
         __typename: 'OneColumnTemplate',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/ticket-details.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/ticket-details.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_TICKET_DETAILS_EN: CMS.Model.Page.Page = {
     id: '3',
@@ -17,7 +17,7 @@ export const PAGE_TICKET_DETAILS_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/cases',
@@ -61,7 +61,7 @@ export const PAGE_TICKET_DETAILS_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/faelle',
@@ -105,7 +105,7 @@ export const PAGE_TICKET_DETAILS_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     parent: {
         slug: '/zgloszenia',

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/ticket-list.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/ticket-list.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_TICKET_LIST_EN: CMS.Model.Page.Page = {
     id: '2',
@@ -18,7 +18,7 @@ export const PAGE_TICKET_LIST_EN: CMS.Model.Page.Page = {
         },
     },
     hasOwnTitle: true,
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER],
     template: {
         __typename: 'OneColumnTemplate',
         slots: {
@@ -56,7 +56,7 @@ export const PAGE_TICKET_LIST_DE: CMS.Model.Page.Page = {
         },
     },
     hasOwnTitle: true,
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     template: {
         __typename: 'OneColumnTemplate',
         slots: {
@@ -94,7 +94,7 @@ export const PAGE_TICKET_LIST_PL: CMS.Model.Page.Page = {
         },
     },
     hasOwnTitle: true,
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     template: {
         __typename: 'OneColumnTemplate',
         slots: {

--- a/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/user-account.page.ts
+++ b/packages/integrations/mocked/src/modules/cms/mappers/mocks/pages/user-account.page.ts
@@ -1,4 +1,4 @@
-import { CMS } from '@o2s/framework/modules';
+import { Auth, CMS } from '@o2s/framework/modules';
 
 export const PAGE_USER_ACCOUNT_EN: CMS.Model.Page.Page = {
     id: '7',
@@ -17,7 +17,7 @@ export const PAGE_USER_ACCOUNT_EN: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     template: {
         __typename: 'OneColumnTemplate',
@@ -51,7 +51,7 @@ export const PAGE_USER_ACCOUNT_DE: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     template: {
         __typename: 'OneColumnTemplate',
@@ -85,7 +85,7 @@ export const PAGE_USER_ACCOUNT_PL: CMS.Model.Page.Page = {
             alt: 'Placeholder',
         },
     },
-    isProtected: true,
+    permissions: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
     hasOwnTitle: true,
     template: {
         __typename: 'OneColumnTemplate',

--- a/packages/integrations/mocked/src/modules/users/customers.mapper.ts
+++ b/packages/integrations/mocked/src/modules/users/customers.mapper.ts
@@ -1,4 +1,4 @@
-import { Models } from '@o2s/framework/modules';
+import { Auth, Models } from '@o2s/framework/modules';
 
 const MOCK_CUSTOMER_1: Models.Customer.Customer = {
     id: 'cust-001',
@@ -16,10 +16,10 @@ const MOCK_CUSTOMER_1: Models.Customer.Customer = {
     },
     roles: [
         {
-            role: 'selfservice_user',
+            roles: [Auth.Constants.Roles.USER],
         },
         {
-            role: 'selfservice_admin',
+            roles: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
         },
     ],
     parentOrgId: 'org-001',
@@ -41,7 +41,7 @@ const MOCK_CUSTOMER_2: Models.Customer.Customer = {
     },
     roles: [
         {
-            role: 'selfservice_user',
+            roles: [Auth.Constants.Roles.USER],
         },
     ],
     parentOrgId: 'org-002',
@@ -63,7 +63,7 @@ const MOCK_CUSTOMER_3: Models.Customer.Customer = {
     },
     roles: [
         {
-            role: 'selfservice_admin',
+            roles: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
         },
     ],
     parentOrgId: 'org-003',

--- a/packages/integrations/mocked/src/modules/users/users.mapper.ts
+++ b/packages/integrations/mocked/src/modules/users/users.mapper.ts
@@ -1,9 +1,4 @@
-import { Users } from '@o2s/framework/modules';
-
-const dateToday = new Date();
-dateToday.setHours(dateToday.getHours() - 1);
-const dateYesterday = new Date();
-dateYesterday.setDate(dateYesterday.getDate() - 1);
+import { Auth, Users } from '@o2s/framework/modules';
 
 const MOCK_USER_1: Users.Model.User = {
     id: 'user-100',
@@ -17,7 +12,7 @@ const MOCK_USER_1: Users.Model.User = {
                 name: 'Acme Corporation',
                 clientType: 'B2B',
             },
-            role: 'selfservice_admin',
+            roles: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
         },
         {
             customer: {
@@ -25,7 +20,7 @@ const MOCK_USER_1: Users.Model.User = {
                 name: 'Retail Customer Ltd',
                 clientType: 'B2C',
             },
-            role: 'selfservice_user',
+            roles: [Auth.Constants.Roles.USER],
         },
     ],
     customers: [],
@@ -43,7 +38,7 @@ const MOCK_USER_2: Users.Model.User = {
                 name: 'Tech Solutions Inc',
                 clientType: 'B2B',
             },
-            role: 'selfservice_manager',
+            roles: [Auth.Constants.Roles.USER],
         },
         {
             customer: {
@@ -51,7 +46,7 @@ const MOCK_USER_2: Users.Model.User = {
                 name: 'Digital Services GmbH',
                 clientType: 'B2B',
             },
-            role: 'selfservice_admin',
+            roles: [Auth.Constants.Roles.USER, Auth.Constants.Roles.ADMIN],
         },
     ],
     customers: [],

--- a/packages/integrations/strapi-cms/generated/strapi.ts
+++ b/packages/integrations/strapi-cms/generated/strapi.ts
@@ -66,7 +66,7 @@ export type Article = {
     localizations: Array<Maybe<Article>>;
     localizations_connection?: Maybe<ArticleRelationResponseCollection>;
     parent?: Maybe<Page>;
-    protected?: Maybe<Scalars['Boolean']['output']>;
+    permissions?: Maybe<ComponentSeoUserRoles>;
     publishedAt?: Maybe<Scalars['DateTime']['output']>;
     slug: Scalars['String']['output'];
     updatedAt?: Maybe<Scalars['DateTime']['output']>;
@@ -100,7 +100,7 @@ export type ArticleFiltersInput = {
     not?: InputMaybe<ArticleFiltersInput>;
     or?: InputMaybe<Array<InputMaybe<ArticleFiltersInput>>>;
     parent?: InputMaybe<PageFiltersInput>;
-    protected?: InputMaybe<BooleanFilterInput>;
+    permissions?: InputMaybe<ComponentSeoUserRolesFiltersInput>;
     publishedAt?: InputMaybe<DateTimeFilterInput>;
     slug?: InputMaybe<StringFilterInput>;
     updatedAt?: InputMaybe<DateTimeFilterInput>;
@@ -110,7 +110,7 @@ export type ArticleInput = {
     SEO?: InputMaybe<ComponentSeoSeoInput>;
     content?: InputMaybe<ComponentComponentsArticleInput>;
     parent?: InputMaybe<Scalars['ID']['input']>;
-    protected?: InputMaybe<Scalars['Boolean']['input']>;
+    permissions?: InputMaybe<ComponentSeoUserRolesInput>;
     publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
     slug?: InputMaybe<Scalars['String']['input']>;
 };
@@ -696,14 +696,6 @@ export type ComponentComponentsUserAccountInputsArgs = {
     sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
-export type ComponentContentActionLinks = {
-    icon?: Maybe<Scalars['String']['output']>;
-    id: Scalars['ID']['output'];
-    label: Scalars['String']['output'];
-    page?: Maybe<Page>;
-    url?: Maybe<Scalars['String']['output']>;
-};
-
 export type ComponentContentAlertBox = {
     description?: Maybe<Scalars['String']['output']>;
     id: Scalars['ID']['output'];
@@ -829,6 +821,12 @@ export type ComponentContentFieldMappingFiltersInput = {
     not?: InputMaybe<ComponentContentFieldMappingFiltersInput>;
     or?: InputMaybe<Array<InputMaybe<ComponentContentFieldMappingFiltersInput>>>;
     values?: InputMaybe<ComponentContentKeyValueFiltersInput>;
+};
+
+export type ComponentContentFieldMappingInput = {
+    id?: InputMaybe<Scalars['ID']['input']>;
+    name?: InputMaybe<Scalars['String']['input']>;
+    values?: InputMaybe<Array<InputMaybe<ComponentContentKeyValueInput>>>;
 };
 
 export type ComponentContentFilterDateRange = {
@@ -1390,6 +1388,23 @@ export type ComponentSeoSeoInput = {
     title?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type ComponentSeoUserRoles = {
+    id: Scalars['ID']['output'];
+    roles?: Maybe<Scalars['JSON']['output']>;
+};
+
+export type ComponentSeoUserRolesFiltersInput = {
+    and?: InputMaybe<Array<InputMaybe<ComponentSeoUserRolesFiltersInput>>>;
+    not?: InputMaybe<ComponentSeoUserRolesFiltersInput>;
+    or?: InputMaybe<Array<InputMaybe<ComponentSeoUserRolesFiltersInput>>>;
+    roles?: InputMaybe<JsonFilterInput>;
+};
+
+export type ComponentSeoUserRolesInput = {
+    id?: InputMaybe<Scalars['ID']['input']>;
+    roles?: InputMaybe<Scalars['JSON']['input']>;
+};
+
 export type ComponentTemplatesOneColumn = {
     id: Scalars['ID']['output'];
     mainSlot: Array<Maybe<Component>>;
@@ -1827,7 +1842,6 @@ export type GenericMorph =
     | ComponentComponentsTicketList
     | ComponentComponentsTicketRecent
     | ComponentComponentsUserAccount
-    | ComponentContentActionLinks
     | ComponentContentAlertBox
     | ComponentContentArticleSection
     | ComponentContentBanner
@@ -1862,6 +1876,7 @@ export type GenericMorph =
     | ComponentLabelsValidation
     | ComponentSeoMetadata
     | ComponentSeoSeo
+    | ComponentSeoUserRoles
     | ComponentTemplatesOneColumn
     | ComponentTemplatesTwoColumn
     | ConfigurableTexts
@@ -1872,6 +1887,7 @@ export type GenericMorph =
     | Header
     | I18NLocale
     | LoginPage
+    | Mapping
     | NotFoundPage
     | OrganizationList
     | Page
@@ -2107,6 +2123,38 @@ export type LoginPageRelationResponseCollection = {
     nodes: Array<LoginPage>;
 };
 
+export type Mapping = {
+    createdAt?: Maybe<Scalars['DateTime']['output']>;
+    documentId: Scalars['ID']['output'];
+    fields?: Maybe<ComponentContentFieldMapping>;
+    name: Scalars['String']['output'];
+    publishedAt?: Maybe<Scalars['DateTime']['output']>;
+    updatedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type MappingEntityResponseCollection = {
+    nodes: Array<Mapping>;
+    pageInfo: Pagination;
+};
+
+export type MappingFiltersInput = {
+    and?: InputMaybe<Array<InputMaybe<MappingFiltersInput>>>;
+    createdAt?: InputMaybe<DateTimeFilterInput>;
+    documentId?: InputMaybe<IdFilterInput>;
+    fields?: InputMaybe<ComponentContentFieldMappingFiltersInput>;
+    name?: InputMaybe<StringFilterInput>;
+    not?: InputMaybe<MappingFiltersInput>;
+    or?: InputMaybe<Array<InputMaybe<MappingFiltersInput>>>;
+    publishedAt?: InputMaybe<DateTimeFilterInput>;
+    updatedAt?: InputMaybe<DateTimeFilterInput>;
+};
+
+export type MappingInput = {
+    fields?: InputMaybe<ComponentContentFieldMappingInput>;
+    name?: InputMaybe<Scalars['String']['input']>;
+    publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
 export type Mutation = {
     /** Change user password. Confirm with the current password. */
     changePassword?: Maybe<UsersPermissionsLoginPayload>;
@@ -2117,6 +2165,7 @@ export type Mutation = {
     createFilterItem?: Maybe<FilterItem>;
     createFooter?: Maybe<Footer>;
     createHeader?: Maybe<Header>;
+    createMapping?: Maybe<Mapping>;
     createPage?: Maybe<Page>;
     createReviewWorkflowsWorkflow?: Maybe<ReviewWorkflowsWorkflow>;
     createReviewWorkflowsWorkflowStage?: Maybe<ReviewWorkflowsWorkflowStage>;
@@ -2139,6 +2188,7 @@ export type Mutation = {
     deleteFooter?: Maybe<DeleteMutationResponse>;
     deleteHeader?: Maybe<DeleteMutationResponse>;
     deleteLoginPage?: Maybe<DeleteMutationResponse>;
+    deleteMapping?: Maybe<DeleteMutationResponse>;
     deleteNotFoundPage?: Maybe<DeleteMutationResponse>;
     deleteOrganizationList?: Maybe<DeleteMutationResponse>;
     deletePage?: Maybe<DeleteMutationResponse>;
@@ -2174,6 +2224,7 @@ export type Mutation = {
     updateFooter?: Maybe<Footer>;
     updateHeader?: Maybe<Header>;
     updateLoginPage?: Maybe<LoginPage>;
+    updateMapping?: Maybe<Mapping>;
     updateNotFoundPage?: Maybe<NotFoundPage>;
     updateOrganizationList?: Maybe<OrganizationList>;
     updatePage?: Maybe<Page>;
@@ -2235,6 +2286,11 @@ export type MutationCreateFooterArgs = {
 export type MutationCreateHeaderArgs = {
     data: HeaderInput;
     locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>;
+    status?: InputMaybe<PublicationStatus>;
+};
+
+export type MutationCreateMappingArgs = {
+    data: MappingInput;
     status?: InputMaybe<PublicationStatus>;
 };
 
@@ -2330,6 +2386,10 @@ export type MutationDeleteHeaderArgs = {
 
 export type MutationDeleteLoginPageArgs = {
     locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>;
+};
+
+export type MutationDeleteMappingArgs = {
+    documentId: Scalars['ID']['input'];
 };
 
 export type MutationDeleteNotFoundPageArgs = {
@@ -2482,6 +2542,12 @@ export type MutationUpdateLoginPageArgs = {
     status?: InputMaybe<PublicationStatus>;
 };
 
+export type MutationUpdateMappingArgs = {
+    data: MappingInput;
+    documentId: Scalars['ID']['input'];
+    status?: InputMaybe<PublicationStatus>;
+};
+
 export type MutationUpdateNotFoundPageArgs = {
     data: NotFoundPageInput;
     locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>;
@@ -2612,7 +2678,7 @@ export type Page = {
     localizations: Array<Maybe<Page>>;
     localizations_connection?: Maybe<PageRelationResponseCollection>;
     parent?: Maybe<Page>;
-    protected?: Maybe<Scalars['Boolean']['output']>;
+    permissions?: Maybe<ComponentSeoUserRoles>;
     publishedAt?: Maybe<Scalars['DateTime']['output']>;
     slug: Scalars['String']['output'];
     template: Array<Maybe<PageTemplateDynamicZone>>;
@@ -2648,7 +2714,7 @@ export type PageFiltersInput = {
     not?: InputMaybe<PageFiltersInput>;
     or?: InputMaybe<Array<InputMaybe<PageFiltersInput>>>;
     parent?: InputMaybe<PageFiltersInput>;
-    protected?: InputMaybe<BooleanFilterInput>;
+    permissions?: InputMaybe<ComponentSeoUserRolesFiltersInput>;
     publishedAt?: InputMaybe<DateTimeFilterInput>;
     slug?: InputMaybe<StringFilterInput>;
     updatedAt?: InputMaybe<DateTimeFilterInput>;
@@ -2659,7 +2725,7 @@ export type PageInput = {
     child?: InputMaybe<Scalars['ID']['input']>;
     hasOwnTitle?: InputMaybe<Scalars['Boolean']['input']>;
     parent?: InputMaybe<Scalars['ID']['input']>;
-    protected?: InputMaybe<Scalars['Boolean']['input']>;
+    permissions?: InputMaybe<ComponentSeoUserRolesInput>;
     publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
     slug?: InputMaybe<Scalars['String']['input']>;
     template?: InputMaybe<Array<Scalars['PageTemplateDynamicZoneInput']['input']>>;
@@ -2720,6 +2786,9 @@ export type Query = {
     i18NLocales: Array<Maybe<I18NLocale>>;
     i18NLocales_connection?: Maybe<I18NLocaleEntityResponseCollection>;
     loginPage?: Maybe<LoginPage>;
+    mapping?: Maybe<Mapping>;
+    mappings: Array<Maybe<Mapping>>;
+    mappings_connection?: Maybe<MappingEntityResponseCollection>;
     me?: Maybe<UsersPermissionsMe>;
     notFoundPage?: Maybe<NotFoundPage>;
     organizationList?: Maybe<OrganizationList>;
@@ -2948,6 +3017,25 @@ export type QueryI18NLocales_ConnectionArgs = {
 
 export type QueryLoginPageArgs = {
     locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>;
+    status?: InputMaybe<PublicationStatus>;
+};
+
+export type QueryMappingArgs = {
+    documentId: Scalars['ID']['input'];
+    status?: InputMaybe<PublicationStatus>;
+};
+
+export type QueryMappingsArgs = {
+    filters?: InputMaybe<MappingFiltersInput>;
+    pagination?: InputMaybe<PaginationArg>;
+    sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+    status?: InputMaybe<PublicationStatus>;
+};
+
+export type QueryMappings_ConnectionArgs = {
+    filters?: InputMaybe<MappingFiltersInput>;
+    pagination?: InputMaybe<PaginationArg>;
+    sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
     status?: InputMaybe<PublicationStatus>;
 };
 
@@ -3293,7 +3381,7 @@ export type SurveyJsForm = {
     documentId: Scalars['ID']['output'];
     postId: Scalars['String']['output'];
     publishedAt?: Maybe<Scalars['DateTime']['output']>;
-    requiredRoles: Scalars['JSON']['output'];
+    requiredRoles: ComponentSeoUserRoles;
     submitDestination?: Maybe<Scalars['JSON']['output']>;
     surveyId: Scalars['String']['output'];
     surveyType: Scalars['String']['output'];
@@ -3314,7 +3402,7 @@ export type SurveyJsFormFiltersInput = {
     or?: InputMaybe<Array<InputMaybe<SurveyJsFormFiltersInput>>>;
     postId?: InputMaybe<StringFilterInput>;
     publishedAt?: InputMaybe<DateTimeFilterInput>;
-    requiredRoles?: InputMaybe<JsonFilterInput>;
+    requiredRoles?: InputMaybe<ComponentSeoUserRolesFiltersInput>;
     submitDestination?: InputMaybe<JsonFilterInput>;
     surveyId?: InputMaybe<StringFilterInput>;
     surveyType?: InputMaybe<StringFilterInput>;
@@ -3325,7 +3413,7 @@ export type SurveyJsFormInput = {
     code?: InputMaybe<Scalars['String']['input']>;
     postId?: InputMaybe<Scalars['String']['input']>;
     publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
-    requiredRoles?: InputMaybe<Scalars['JSON']['input']>;
+    requiredRoles?: InputMaybe<ComponentSeoUserRolesInput>;
     submitDestination?: InputMaybe<Scalars['JSON']['input']>;
     surveyId?: InputMaybe<Scalars['String']['input']>;
     surveyType?: InputMaybe<Scalars['String']['input']>;
@@ -3958,7 +4046,6 @@ export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = {
           })
         | ComponentComponentsTicketRecent
         | ComponentComponentsUserAccount
-        | (Omit<ComponentContentActionLinks, 'page'> & { page?: Maybe<_RefType['Page']> })
         | ComponentContentAlertBox
         | ComponentContentArticleSection
         | (Omit<ComponentContentBanner, 'button'> & { button?: Maybe<_RefType['ComponentContentLink']> })
@@ -4000,6 +4087,7 @@ export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = {
         | ComponentLabelsValidation
         | ComponentSeoMetadata
         | (Omit<ComponentSeoSeo, 'image'> & { image?: Maybe<_RefType['UploadFile']> })
+        | ComponentSeoUserRoles
         | (Omit<ComponentTemplatesOneColumn, 'mainSlot' | 'mainSlot_connection'> & {
               mainSlot: Array<Maybe<_RefType['Component']>>;
               mainSlot_connection?: Maybe<_RefType['ComponentRelationResponseCollection']>;
@@ -4067,6 +4155,7 @@ export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = {
               localizations: Array<Maybe<_RefType['LoginPage']>>;
               localizations_connection?: Maybe<_RefType['LoginPageRelationResponseCollection']>;
           })
+        | Mapping
         | (Omit<NotFoundPage, 'localizations' | 'localizations_connection' | 'page'> & {
               localizations: Array<Maybe<_RefType['NotFoundPage']>>;
               localizations_connection?: Maybe<_RefType['NotFoundPageRelationResponseCollection']>;
@@ -4333,9 +4422,6 @@ export type ResolversTypes = {
     >;
     ComponentComponentsTicketRecent: ResolverTypeWrapper<ComponentComponentsTicketRecent>;
     ComponentComponentsUserAccount: ResolverTypeWrapper<ComponentComponentsUserAccount>;
-    ComponentContentActionLinks: ResolverTypeWrapper<
-        Omit<ComponentContentActionLinks, 'page'> & { page?: Maybe<ResolversTypes['Page']> }
-    >;
     ComponentContentAlertBox: ResolverTypeWrapper<ComponentContentAlertBox>;
     ComponentContentAlertBoxInput: ComponentContentAlertBoxInput;
     ComponentContentArticleSection: ResolverTypeWrapper<ComponentContentArticleSection>;
@@ -4355,6 +4441,7 @@ export type ResolversTypes = {
     ComponentContentErrorMessageInput: ComponentContentErrorMessageInput;
     ComponentContentFieldMapping: ResolverTypeWrapper<ComponentContentFieldMapping>;
     ComponentContentFieldMappingFiltersInput: ComponentContentFieldMappingFiltersInput;
+    ComponentContentFieldMappingInput: ComponentContentFieldMappingInput;
     ComponentContentFilterDateRange: ResolverTypeWrapper<ComponentContentFilterDateRange>;
     ComponentContentFilterSelect: ResolverTypeWrapper<ComponentContentFilterSelect>;
     ComponentContentFilters: ResolverTypeWrapper<
@@ -4438,6 +4525,9 @@ export type ResolversTypes = {
     >;
     ComponentSeoSeoFiltersInput: ComponentSeoSeoFiltersInput;
     ComponentSeoSeoInput: ComponentSeoSeoInput;
+    ComponentSeoUserRoles: ResolverTypeWrapper<ComponentSeoUserRoles>;
+    ComponentSeoUserRolesFiltersInput: ComponentSeoUserRolesFiltersInput;
+    ComponentSeoUserRolesInput: ComponentSeoUserRolesInput;
     ComponentTemplatesOneColumn: ResolverTypeWrapper<
         Omit<ComponentTemplatesOneColumn, 'mainSlot' | 'mainSlot_connection'> & {
             mainSlot: Array<Maybe<ResolversTypes['Component']>>;
@@ -4586,6 +4676,10 @@ export type ResolversTypes = {
     LoginPageRelationResponseCollection: ResolverTypeWrapper<
         Omit<LoginPageRelationResponseCollection, 'nodes'> & { nodes: Array<ResolversTypes['LoginPage']> }
     >;
+    Mapping: ResolverTypeWrapper<Mapping>;
+    MappingEntityResponseCollection: ResolverTypeWrapper<MappingEntityResponseCollection>;
+    MappingFiltersInput: MappingFiltersInput;
+    MappingInput: MappingInput;
     Mutation: ResolverTypeWrapper<{}>;
     NotFoundPage: ResolverTypeWrapper<
         Omit<NotFoundPage, 'localizations' | 'localizations_connection' | 'page'> & {
@@ -4872,9 +4966,6 @@ export type ResolversParentTypes = {
     };
     ComponentComponentsTicketRecent: ComponentComponentsTicketRecent;
     ComponentComponentsUserAccount: ComponentComponentsUserAccount;
-    ComponentContentActionLinks: Omit<ComponentContentActionLinks, 'page'> & {
-        page?: Maybe<ResolversParentTypes['Page']>;
-    };
     ComponentContentAlertBox: ComponentContentAlertBox;
     ComponentContentAlertBoxInput: ComponentContentAlertBoxInput;
     ComponentContentArticleSection: ComponentContentArticleSection;
@@ -4892,6 +4983,7 @@ export type ResolversParentTypes = {
     ComponentContentErrorMessageInput: ComponentContentErrorMessageInput;
     ComponentContentFieldMapping: ComponentContentFieldMapping;
     ComponentContentFieldMappingFiltersInput: ComponentContentFieldMappingFiltersInput;
+    ComponentContentFieldMappingInput: ComponentContentFieldMappingInput;
     ComponentContentFilterDateRange: ComponentContentFilterDateRange;
     ComponentContentFilterSelect: ComponentContentFilterSelect;
     ComponentContentFilters: Omit<ComponentContentFilters, 'items' | 'items_connection'> & {
@@ -4965,6 +5057,9 @@ export type ResolversParentTypes = {
     ComponentSeoSeo: Omit<ComponentSeoSeo, 'image'> & { image?: Maybe<ResolversParentTypes['UploadFile']> };
     ComponentSeoSeoFiltersInput: ComponentSeoSeoFiltersInput;
     ComponentSeoSeoInput: ComponentSeoSeoInput;
+    ComponentSeoUserRoles: ComponentSeoUserRoles;
+    ComponentSeoUserRolesFiltersInput: ComponentSeoUserRolesFiltersInput;
+    ComponentSeoUserRolesInput: ComponentSeoUserRolesInput;
     ComponentTemplatesOneColumn: Omit<ComponentTemplatesOneColumn, 'mainSlot' | 'mainSlot_connection'> & {
         mainSlot: Array<Maybe<ResolversParentTypes['Component']>>;
         mainSlot_connection?: Maybe<ResolversParentTypes['ComponentRelationResponseCollection']>;
@@ -5099,6 +5194,10 @@ export type ResolversParentTypes = {
     LoginPageRelationResponseCollection: Omit<LoginPageRelationResponseCollection, 'nodes'> & {
         nodes: Array<ResolversParentTypes['LoginPage']>;
     };
+    Mapping: Mapping;
+    MappingEntityResponseCollection: MappingEntityResponseCollection;
+    MappingFiltersInput: MappingFiltersInput;
+    MappingInput: MappingInput;
     Mutation: {};
     NotFoundPage: Omit<NotFoundPage, 'localizations' | 'localizations_connection' | 'page'> & {
         localizations: Array<Maybe<ResolversParentTypes['NotFoundPage']>>;
@@ -5251,7 +5350,7 @@ export type ArticleResolvers<
         RequireFields<ArticleLocalizations_ConnectionArgs, 'pagination' | 'sort'>
     >;
     parent?: Resolver<Maybe<ResolversTypes['Page']>, ParentType, ContextType>;
-    protected?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+    permissions?: Resolver<Maybe<ResolversTypes['ComponentSeoUserRoles']>, ParentType, ContextType>;
     publishedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
     slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
     updatedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
@@ -5875,19 +5974,6 @@ export type ComponentComponentsUserAccountResolvers<
     __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ComponentContentActionLinksResolvers<
-    ContextType = any,
-    ParentType extends
-        ResolversParentTypes['ComponentContentActionLinks'] = ResolversParentTypes['ComponentContentActionLinks'],
-> = {
-    icon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-    id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-    label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-    page?: Resolver<Maybe<ResolversTypes['Page']>, ParentType, ContextType>;
-    url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-    __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
 export type ComponentContentAlertBoxResolvers<
     ContextType = any,
     ParentType extends
@@ -6446,6 +6532,15 @@ export type ComponentSeoSeoResolvers<
     __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type ComponentSeoUserRolesResolvers<
+    ContextType = any,
+    ParentType extends ResolversParentTypes['ComponentSeoUserRoles'] = ResolversParentTypes['ComponentSeoUserRoles'],
+> = {
+    id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+    roles?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+    __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type ComponentTemplatesOneColumnResolvers<
     ContextType = any,
     ParentType extends
@@ -6822,7 +6917,6 @@ export type GenericMorphResolvers<
         | 'ComponentComponentsTicketList'
         | 'ComponentComponentsTicketRecent'
         | 'ComponentComponentsUserAccount'
-        | 'ComponentContentActionLinks'
         | 'ComponentContentAlertBox'
         | 'ComponentContentArticleSection'
         | 'ComponentContentBanner'
@@ -6857,6 +6951,7 @@ export type GenericMorphResolvers<
         | 'ComponentLabelsValidation'
         | 'ComponentSeoMetadata'
         | 'ComponentSeoSeo'
+        | 'ComponentSeoUserRoles'
         | 'ComponentTemplatesOneColumn'
         | 'ComponentTemplatesTwoColumn'
         | 'ConfigurableTexts'
@@ -6867,6 +6962,7 @@ export type GenericMorphResolvers<
         | 'Header'
         | 'I18NLocale'
         | 'LoginPage'
+        | 'Mapping'
         | 'NotFoundPage'
         | 'OrganizationList'
         | 'Page'
@@ -7025,6 +7121,29 @@ export type LoginPageRelationResponseCollectionResolvers<
     __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type MappingResolvers<
+    ContextType = any,
+    ParentType extends ResolversParentTypes['Mapping'] = ResolversParentTypes['Mapping'],
+> = {
+    createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+    documentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+    fields?: Resolver<Maybe<ResolversTypes['ComponentContentFieldMapping']>, ParentType, ContextType>;
+    name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+    publishedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+    updatedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+    __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type MappingEntityResponseCollectionResolvers<
+    ContextType = any,
+    ParentType extends
+        ResolversParentTypes['MappingEntityResponseCollection'] = ResolversParentTypes['MappingEntityResponseCollection'],
+> = {
+    nodes?: Resolver<Array<ResolversTypes['Mapping']>, ParentType, ContextType>;
+    pageInfo?: Resolver<ResolversTypes['Pagination'], ParentType, ContextType>;
+    __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type MutationResolvers<
     ContextType = any,
     ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation'],
@@ -7076,6 +7195,12 @@ export type MutationResolvers<
         ParentType,
         ContextType,
         RequireFields<MutationCreateHeaderArgs, 'data' | 'status'>
+    >;
+    createMapping?: Resolver<
+        Maybe<ResolversTypes['Mapping']>,
+        ParentType,
+        ContextType,
+        RequireFields<MutationCreateMappingArgs, 'data' | 'status'>
     >;
     createPage?: Resolver<
         Maybe<ResolversTypes['Page']>,
@@ -7196,6 +7321,12 @@ export type MutationResolvers<
         ParentType,
         ContextType,
         Partial<MutationDeleteLoginPageArgs>
+    >;
+    deleteMapping?: Resolver<
+        Maybe<ResolversTypes['DeleteMutationResponse']>,
+        ParentType,
+        ContextType,
+        RequireFields<MutationDeleteMappingArgs, 'documentId'>
     >;
     deleteNotFoundPage?: Resolver<
         Maybe<ResolversTypes['DeleteMutationResponse']>,
@@ -7371,6 +7502,12 @@ export type MutationResolvers<
         ContextType,
         RequireFields<MutationUpdateLoginPageArgs, 'data' | 'status'>
     >;
+    updateMapping?: Resolver<
+        Maybe<ResolversTypes['Mapping']>,
+        ParentType,
+        ContextType,
+        RequireFields<MutationUpdateMappingArgs, 'data' | 'documentId' | 'status'>
+    >;
     updateNotFoundPage?: Resolver<
         Maybe<ResolversTypes['NotFoundPage']>,
         ParentType,
@@ -7529,7 +7666,7 @@ export type PageResolvers<
         RequireFields<PageLocalizations_ConnectionArgs, 'pagination' | 'sort'>
     >;
     parent?: Resolver<Maybe<ResolversTypes['Page']>, ParentType, ContextType>;
-    protected?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+    permissions?: Resolver<Maybe<ResolversTypes['ComponentSeoUserRoles']>, ParentType, ContextType>;
     publishedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
     slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
     template?: Resolver<Array<Maybe<ResolversTypes['PageTemplateDynamicZone']>>, ParentType, ContextType>;
@@ -7761,6 +7898,24 @@ export type QueryResolvers<
         ParentType,
         ContextType,
         RequireFields<QueryLoginPageArgs, 'status'>
+    >;
+    mapping?: Resolver<
+        Maybe<ResolversTypes['Mapping']>,
+        ParentType,
+        ContextType,
+        RequireFields<QueryMappingArgs, 'documentId' | 'status'>
+    >;
+    mappings?: Resolver<
+        Array<Maybe<ResolversTypes['Mapping']>>,
+        ParentType,
+        ContextType,
+        RequireFields<QueryMappingsArgs, 'pagination' | 'sort' | 'status'>
+    >;
+    mappings_connection?: Resolver<
+        Maybe<ResolversTypes['MappingEntityResponseCollection']>,
+        ParentType,
+        ContextType,
+        RequireFields<QueryMappings_ConnectionArgs, 'pagination' | 'sort' | 'status'>
     >;
     me?: Resolver<Maybe<ResolversTypes['UsersPermissionsMe']>, ParentType, ContextType>;
     notFoundPage?: Resolver<
@@ -8059,7 +8214,7 @@ export type SurveyJsFormResolvers<
     documentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
     postId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
     publishedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-    requiredRoles?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+    requiredRoles?: Resolver<ResolversTypes['ComponentSeoUserRoles'], ParentType, ContextType>;
     submitDestination?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
     surveyId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
     surveyType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -8399,7 +8554,6 @@ export type Resolvers<ContextType = any> = {
     ComponentComponentsTicketList?: ComponentComponentsTicketListResolvers<ContextType>;
     ComponentComponentsTicketRecent?: ComponentComponentsTicketRecentResolvers<ContextType>;
     ComponentComponentsUserAccount?: ComponentComponentsUserAccountResolvers<ContextType>;
-    ComponentContentActionLinks?: ComponentContentActionLinksResolvers<ContextType>;
     ComponentContentAlertBox?: ComponentContentAlertBoxResolvers<ContextType>;
     ComponentContentArticleSection?: ComponentContentArticleSectionResolvers<ContextType>;
     ComponentContentBanner?: ComponentContentBannerResolvers<ContextType>;
@@ -8438,6 +8592,7 @@ export type Resolvers<ContextType = any> = {
     ComponentRelationResponseCollection?: ComponentRelationResponseCollectionResolvers<ContextType>;
     ComponentSeoMetadata?: ComponentSeoMetadataResolvers<ContextType>;
     ComponentSeoSeo?: ComponentSeoSeoResolvers<ContextType>;
+    ComponentSeoUserRoles?: ComponentSeoUserRolesResolvers<ContextType>;
     ComponentTemplatesOneColumn?: ComponentTemplatesOneColumnResolvers<ContextType>;
     ComponentTemplatesTwoColumn?: ComponentTemplatesTwoColumnResolvers<ContextType>;
     ConfigurableTexts?: ConfigurableTextsResolvers<ContextType>;
@@ -8471,6 +8626,8 @@ export type Resolvers<ContextType = any> = {
     JSON?: GraphQLScalarType;
     LoginPage?: LoginPageResolvers<ContextType>;
     LoginPageRelationResponseCollection?: LoginPageRelationResponseCollectionResolvers<ContextType>;
+    Mapping?: MappingResolvers<ContextType>;
+    MappingEntityResponseCollection?: MappingEntityResponseCollectionResolvers<ContextType>;
     Mutation?: MutationResolvers<ContextType>;
     NotFoundPage?: NotFoundPageResolvers<ContextType>;
     NotFoundPageRelationResponseCollection?: NotFoundPageRelationResponseCollectionResolvers<ContextType>;
@@ -8519,11 +8676,11 @@ export type Resolvers<ContextType = any> = {
 export type ArticleSimpleFragment = {
     documentId: string;
     slug: string;
-    protected?: boolean;
     locale?: string;
     createdAt?: any;
     updatedAt?: any;
     publishedAt?: any;
+    permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any };
     SEO: {
         title: string;
         noIndex: boolean;
@@ -8552,7 +8709,6 @@ export type ArticleSimpleFragment = {
 export type ArticleFragment = {
     documentId: string;
     slug: string;
-    protected?: boolean;
     locale?: string;
     createdAt?: any;
     updatedAt?: any;
@@ -8568,6 +8724,7 @@ export type ArticleFragment = {
         };
         category?: { documentId: string; slug: string; name: string };
     };
+    permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any };
     SEO: {
         title: string;
         noIndex: boolean;
@@ -8604,7 +8761,6 @@ export type GetArticleQuery = {
     articles: Array<{
         documentId: string;
         slug: string;
-        protected?: boolean;
         locale?: string;
         createdAt?: any;
         updatedAt?: any;
@@ -8625,6 +8781,7 @@ export type GetArticleQuery = {
             };
             category?: { documentId: string; slug: string; name: string };
         };
+        permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any };
         SEO: {
             title: string;
             noIndex: boolean;
@@ -8657,11 +8814,11 @@ export type GetArticlesQuery = {
     articles: Array<{
         documentId: string;
         slug: string;
-        protected?: boolean;
         locale?: string;
         createdAt?: any;
         updatedAt?: any;
         publishedAt?: any;
+        permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any };
         SEO: {
             title: string;
             noIndex: boolean;
@@ -8784,7 +8941,7 @@ export type FooterFragment = {
                   url?: string;
                   label: string;
                   description?: string;
-                  page?: { slug: string };
+                  page?: { slug: string; permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any } };
               }>;
           }
         | {
@@ -8793,7 +8950,7 @@ export type FooterFragment = {
               url?: string;
               label: string;
               description?: string;
-              page?: { slug: string };
+              page?: { slug: string; permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any } };
           }
         | {}
     >;
@@ -8817,7 +8974,7 @@ export type HeaderFragment = {
                   url?: string;
                   label: string;
                   description?: string;
-                  page?: { slug: string };
+                  page?: { slug: string; permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any } };
               }>;
           }
         | {
@@ -8826,7 +8983,7 @@ export type HeaderFragment = {
               url?: string;
               label: string;
               description?: string;
-              page?: { slug: string };
+              page?: { slug: string; permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any } };
           }
         | {}
     >;
@@ -8896,12 +9053,12 @@ export type OrganizationListFragment = { documentId: string; title?: string; des
 export type PageFragment = {
     documentId: string;
     slug: string;
-    protected?: boolean;
     locale?: string;
     createdAt?: any;
     updatedAt?: any;
     publishedAt?: any;
     hasOwnTitle: boolean;
+    permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any };
     SEO: {
         title: string;
         noIndex: boolean;
@@ -9075,6 +9232,8 @@ export type PageFragment = {
         | { __typename: 'Error' }
     >;
 };
+
+export type RolesFragment = { __typename: 'ComponentSeoUserRoles'; roles?: any };
 
 type Template_ComponentTemplatesOneColumn_Fragment = {
     __typename: 'ComponentTemplatesOneColumn';
@@ -9963,7 +10122,7 @@ export type NavigationGroupFragment = {
         url?: string;
         label: string;
         description?: string;
-        page?: { slug: string };
+        page?: { slug: string; permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any } };
     }>;
 };
 
@@ -9973,7 +10132,7 @@ export type NavigationItemFragment = {
     url?: string;
     label: string;
     description?: string;
-    page?: { slug: string };
+    page?: { slug: string; permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any } };
 };
 
 export type PaginationFragment = {
@@ -10871,7 +11030,7 @@ export type GetFooterQuery = {
                       url?: string;
                       label: string;
                       description?: string;
-                      page?: { slug: string };
+                      page?: { slug: string; permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any } };
                   }>;
               }
             | {
@@ -10880,7 +11039,7 @@ export type GetFooterQuery = {
                   url?: string;
                   label: string;
                   description?: string;
-                  page?: { slug: string };
+                  page?: { slug: string; permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any } };
               }
             | {}
         >;
@@ -10911,7 +11070,7 @@ export type GetHeaderQuery = {
                       url?: string;
                       label: string;
                       description?: string;
-                      page?: { slug: string };
+                      page?: { slug: string; permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any } };
                   }>;
               }
             | {
@@ -10920,7 +11079,7 @@ export type GetHeaderQuery = {
                   url?: string;
                   label: string;
                   description?: string;
-                  page?: { slug: string };
+                  page?: { slug: string; permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any } };
               }
             | {}
         >;
@@ -11016,12 +11175,12 @@ export type GetPageQuery = {
     pages: Array<{
         documentId: string;
         slug: string;
-        protected?: boolean;
         locale?: string;
         createdAt?: any;
         updatedAt?: any;
         publishedAt?: any;
         hasOwnTitle: boolean;
+        permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any };
         SEO: {
             title: string;
             noIndex: boolean;
@@ -11205,12 +11364,12 @@ export type GetPagesQuery = {
     pages: Array<{
         documentId: string;
         slug: string;
-        protected?: boolean;
         locale?: string;
         createdAt?: any;
         updatedAt?: any;
         publishedAt?: any;
         hasOwnTitle: boolean;
+        permissions?: { __typename: 'ComponentSeoUserRoles'; roles?: any };
         SEO: {
             title: string;
             noIndex: boolean;
@@ -11396,11 +11555,17 @@ export type GetSurveyQuery = {
         surveyId: string;
         postId: string;
         surveyType: string;
-        requiredRoles: any;
         submitDestination?: any;
+        requiredRoles: { __typename: 'ComponentSeoUserRoles'; roles?: any };
     }>;
 };
 
+export const RolesFragmentDoc = gql`
+    fragment Roles on ComponentSeoUserRoles {
+        __typename
+        roles
+    }
+`;
 export const MediaFragmentDoc = gql`
     fragment Media on UploadFile {
         url
@@ -11429,7 +11594,9 @@ export const ArticleSimpleFragmentDoc = gql`
     fragment ArticleSimple on Article {
         documentId
         slug
-        protected
+        permissions {
+            ...Roles
+        }
         locale
         createdAt
         updatedAt
@@ -11473,6 +11640,7 @@ export const ArticleSimpleFragmentDoc = gql`
             }
         }
     }
+    ${RolesFragmentDoc}
     ${SeoFragmentDoc}
     ${MediaFragmentDoc}
 `;
@@ -11529,9 +11697,13 @@ export const NavigationItemFragmentDoc = gql`
         page {
             ... on Page {
                 slug
+                permissions {
+                    ...Roles
+                }
             }
         }
     }
+    ${RolesFragmentDoc}
 `;
 export const NavigationGroupFragmentDoc = gql`
     fragment NavigationGroup on ComponentContentNavigationGroup {
@@ -11708,7 +11880,9 @@ export const PageFragmentDoc = gql`
     fragment Page on Page {
         documentId
         slug
-        protected
+        permissions {
+            ...Roles
+        }
         locale
         createdAt
         updatedAt
@@ -11746,6 +11920,7 @@ export const PageFragmentDoc = gql`
             }
         }
     }
+    ${RolesFragmentDoc}
     ${SeoFragmentDoc}
     ${OneColumnTemplateFragmentDoc}
     ${TwoColumnTemplateFragmentDoc}
@@ -12616,10 +12791,13 @@ export const GetSurveyDocument = gql`
             surveyId
             postId
             surveyType
-            requiredRoles
+            requiredRoles {
+                ...Roles
+            }
             submitDestination
         }
     }
+    ${RolesFragmentDoc}
 `;
 
 export type SdkFunctionWrapper = <T>(

--- a/packages/integrations/strapi-cms/src/modules/articles/articles.mapper.ts
+++ b/packages/integrations/strapi-cms/src/modules/articles/articles.mapper.ts
@@ -1,6 +1,7 @@
 import { Articles } from '@o2s/framework/modules';
 
 import { mapMedia } from '@/modules/cms/mappers/cms.media.mapper';
+import { mapRoles } from '@/modules/cms/mappers/cms.roles.mapper';
 
 import { ArticleFragment, ArticleSimpleFragment, CategoryFragment } from '@/generated/strapi';
 
@@ -33,7 +34,7 @@ export const mapArticle = (page: ArticleFragment, baseUrl: string): Articles.Mod
     return {
         id: page.documentId,
         slug: page.slug,
-        isProtected: !!page.protected,
+        permissions: mapRoles(page.permissions),
         createdAt: page.updatedAt,
         updatedAt: page.updatedAt,
         title: page.SEO.title,
@@ -76,7 +77,7 @@ export const mapArticles = (data: ArticleSimpleFragment[], total: number, baseUr
             return {
                 id: article.documentId,
                 slug: article.slug,
-                isProtected: !!article.protected,
+                permissions: mapRoles(article.permissions),
                 createdAt: article.updatedAt,
                 updatedAt: article.updatedAt,
                 title: article.SEO.title,

--- a/packages/integrations/strapi-cms/src/modules/articles/graphql/fragments/Article.graphql
+++ b/packages/integrations/strapi-cms/src/modules/articles/graphql/fragments/Article.graphql
@@ -1,7 +1,9 @@
 fragment ArticleSimple on Article {
     documentId
     slug
-    protected
+    permissions {
+        ...Roles
+    }
     locale
     createdAt
     updatedAt

--- a/packages/integrations/strapi-cms/src/modules/cms/cms.service.ts
+++ b/packages/integrations/strapi-cms/src/modules/cms/cms.service.ts
@@ -6,7 +6,7 @@ import { parse, stringify } from 'flatted';
 import { Observable, concatMap, forkJoin, from, map, mergeMap, of } from 'rxjs';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { CMS, Cache, Models } from '@o2s/framework/modules';
+import { Auth, CMS, Cache, Models } from '@o2s/framework/modules';
 
 import { Service as GraphqlService } from '@/modules/graphql';
 

--- a/packages/integrations/strapi-cms/src/modules/cms/graphql/fragments/Page.graphql
+++ b/packages/integrations/strapi-cms/src/modules/cms/graphql/fragments/Page.graphql
@@ -1,7 +1,9 @@
 fragment Page on Page {
     documentId
     slug
-    protected
+    permissions {
+        ...Roles
+    }
     locale
     createdAt
     updatedAt

--- a/packages/integrations/strapi-cms/src/modules/cms/graphql/fragments/Roles.graphql
+++ b/packages/integrations/strapi-cms/src/modules/cms/graphql/fragments/Roles.graphql
@@ -1,0 +1,4 @@
+fragment Roles on ComponentSeoUserRoles {
+    __typename
+    roles
+}

--- a/packages/integrations/strapi-cms/src/modules/cms/graphql/fragments/content/NavigationItem.graphql
+++ b/packages/integrations/strapi-cms/src/modules/cms/graphql/fragments/content/NavigationItem.graphql
@@ -7,6 +7,9 @@ fragment NavigationItem on ComponentContentNavigationItem {
     page {
         ... on Page {
             slug
+            permissions {
+                ...Roles
+            }
         }
     }
 }

--- a/packages/integrations/strapi-cms/src/modules/cms/graphql/queries/getSurvey.graphql
+++ b/packages/integrations/strapi-cms/src/modules/cms/graphql/queries/getSurvey.graphql
@@ -4,7 +4,9 @@ query getSurvey($code: String) {
         surveyId
         postId
         surveyType
-        requiredRoles
+        requiredRoles {
+            ...Roles
+        }
         submitDestination
     }
 }

--- a/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.header.mapper.ts
+++ b/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.header.mapper.ts
@@ -2,6 +2,8 @@ import { NotFoundException } from '@nestjs/common';
 
 import { CMS, Models } from '@o2s/framework/modules';
 
+import { mapRoles } from '@/modules/cms/mappers/cms.roles.mapper';
+
 import { GetHeaderQuery, NavigationGroupFragment, NavigationItemFragment } from '@/generated/strapi';
 
 export const mapHeader = (data: GetHeaderQuery, baseURL?: string): CMS.Model.Header.Header => {
@@ -73,5 +75,6 @@ const mapHeaderItem = (item: NavigationItemFragment): Models.Navigation.Navigati
         label: item.label,
         url: item.url || item.page?.slug || '/',
         description: item.description,
+        permissions: mapRoles(item.page?.permissions),
     };
 };

--- a/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.page.mapper.ts
+++ b/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.page.mapper.ts
@@ -2,6 +2,8 @@ import { NotFoundException } from '@nestjs/common';
 
 import { CMS } from '@o2s/framework/modules';
 
+import { mapRoles } from '@/modules/cms/mappers/cms.roles.mapper';
+
 import { ComponentFragment, PageFragment, TemplateFragment } from '@/generated/strapi';
 
 export const mapPage = (data: PageFragment): CMS.Model.Page.Page => {
@@ -12,7 +14,7 @@ export const mapPage = (data: PageFragment): CMS.Model.Page.Page => {
     return {
         id: data.documentId,
         slug: data.slug,
-        isProtected: !!data.protected,
+        permissions: mapRoles(data.permissions),
         locale: data.locale!,
         template: template,
         updatedAt: data.updatedAt,
@@ -60,7 +62,7 @@ export const mapAlternativePages = (data: PageFragment): CMS.Model.Page.Page => 
     return {
         id: data.documentId,
         slug: data.slug,
-        isProtected: !!data.protected,
+        permissions: mapRoles(data.permissions),
         locale: data.locale!,
         template: template,
         updatedAt: data.updatedAt,

--- a/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.roles.mapper.ts
+++ b/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.roles.mapper.ts
@@ -1,0 +1,18 @@
+import { Auth } from '@o2s/framework/modules';
+
+import { RolesFragment } from '@/generated/strapi';
+
+export const mapRoles = (data?: RolesFragment): Auth.Constants.Roles[] => {
+    if (!data?.roles?.length) return [];
+
+    return (data.roles as string[]).reduce<Auth.Constants.Roles[]>((prev, role) => {
+        switch (role) {
+            case 'user':
+                return [...prev, Auth.Constants.Roles.USER];
+            case 'admin':
+                return [...prev, Auth.Constants.Roles.ADMIN];
+        }
+
+        return prev;
+    }, []);
+};

--- a/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.survey.mapper.ts
+++ b/packages/integrations/strapi-cms/src/modules/cms/mappers/cms.survey.mapper.ts
@@ -2,6 +2,8 @@ import { NotFoundException } from '@nestjs/common';
 
 import { CMS } from '@o2s/framework/modules';
 
+import { mapRoles } from '@/modules/cms/mappers/cms.roles.mapper';
+
 import { GetSurveyQuery } from '@/generated/strapi';
 
 export const mapSurvey = (data: GetSurveyQuery): CMS.Model.Survey.Survey => {
@@ -17,6 +19,6 @@ export const mapSurvey = (data: GetSurveyQuery): CMS.Model.Survey.Survey => {
         surveyType: survey.surveyType,
         postId: survey.postId,
         submitDestination: survey.submitDestination ? (survey.submitDestination as string[]) : [],
-        requiredRoles: survey.requiredRoles ? (survey.requiredRoles as string[]) : [],
+        requiredRoles: mapRoles(survey.requiredRoles),
     };
 };


### PR DESCRIPTION
**What does this PR do?**

- implemented user role-based access to pages and articles
- adjusted `Page` and `Article` models to conform with new user-based permission model
- refactored user roles to allow more than one role on organization level and added permission fields on `Page` and `Article` models to allow displaying them based on user roles

