### PR TITLE
feat: add reusable datalist component

### DIFF
--- a/packages/blocks/notification-list/src/frontend/NotificationList.client.tsx
+++ b/packages/blocks/notification-list/src/frontend/NotificationList.client.tsx
@@ -8,16 +8,16 @@ import { Mappings } from '@o2s/utils.frontend';
 
 import { cn } from '@o2s/ui/lib/utils';
 
+import { DataList } from '@o2s/ui/components/DataList';
+import type { DataListColumnConfig } from '@o2s/ui/components/DataList';
 import { FiltersSection } from '@o2s/ui/components/Filters';
 import { NoResults } from '@o2s/ui/components/NoResults';
 import { Pagination } from '@o2s/ui/components/Pagination';
 
-import { Badge } from '@o2s/ui/elements/badge';
 import { BadgeStatus } from '@o2s/ui/elements/badge-status';
 import { Button } from '@o2s/ui/elements/button';
 import { LoadingOverlay } from '@o2s/ui/elements/loading-overlay';
 import { Separator } from '@o2s/ui/elements/separator';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@o2s/ui/elements/table';
 
 import { Model, Request } from '../api-harmonization/notification-list.client';
 import { sdk } from '../sdk';
@@ -62,6 +62,72 @@ export const NotificationListPure: React.FC<NotificationListPureProps> = ({
         });
     };
 
+    // Define columns configuration outside JSX for better readability
+    const columns = data.table.columns.map((column) => {
+        switch (column.id) {
+            case 'status':
+                return {
+                    ...column,
+                    type: 'custom',
+                    title: '',
+                    cellClassName: 'text-center',
+                    render: (_value: unknown, notification: Model.Notification) => {
+                        const isUnViewed = notification.status.value === 'UNVIEWED';
+                        return isUnViewed ? <BadgeStatus variant="default" /> : null;
+                    },
+                };
+            case 'title':
+                return {
+                    ...column,
+                    type: 'text',
+                    cellClassName: (notification: Model.Notification) =>
+                        cn('max-w-[200px] lg:max-w-md', notification.status.value === 'UNVIEWED' && 'font-semibold'),
+                };
+            case 'type':
+                return {
+                    ...column,
+                    type: 'text',
+                    cellClassName: (notification: Model.Notification) =>
+                        cn(notification.status.value === 'UNVIEWED' && 'font-semibold'),
+                };
+            case 'priority':
+                return {
+                    ...column,
+                    type: 'badge',
+                    variant: (value: string) =>
+                        Mappings.NotificationBadge.notificationBadgePriorityVariants[
+                            value as keyof typeof Mappings.NotificationBadge.notificationBadgePriorityVariants
+                        ],
+                };
+            case 'createdAt':
+            case 'updatedAt':
+                return {
+                    ...column,
+                    type: 'date',
+                    cellClassName: (notification: Model.Notification) =>
+                        cn(notification.status.value === 'UNVIEWED' && 'font-semibold'),
+                };
+            default:
+                return {
+                    ...column,
+                    type: 'text',
+                };
+        }
+    }) as DataListColumnConfig<Model.Notification>[];
+    const actions = data.table.actions
+        ? {
+              ...data.table.actions,
+              render: (notification: Model.Notification) => (
+                  <LinkComponent href={notification.detailsUrl}>
+                      <Button variant="link" className="flex items-center justify-end gap-2">
+                          {data.table.actions!.label}
+                          <ArrowRight className="h-4 w-4" />
+                      </Button>
+                  </LinkComponent>
+              ),
+          }
+        : undefined;
+
     return (
         <div className="w-full">
             {initialData.length > 0 ? (
@@ -78,113 +144,15 @@ export const NotificationListPure: React.FC<NotificationListPureProps> = ({
                     <LoadingOverlay isActive={isPending}>
                         {data.notifications.data.length ? (
                             <div className="flex flex-col gap-6">
-                                <Table>
-                                    <TableHeader>
-                                        <TableRow>
-                                            {data.table.columns.map((column) => (
-                                                <TableHead
-                                                    key={column.id}
-                                                    className="py-3 px-4 text-sm text-muted-foreground md:text-nowrap"
-                                                >
-                                                    {column.id !== 'status' ? column.title : null}
-                                                </TableHead>
-                                            ))}
-                                            {data.table.actions && (
-                                                <TableHead className="py-3 px-4 text-sm text-muted-foreground md:text-nowrap">
-                                                    {data.table.actions.title}
-                                                </TableHead>
-                                            )}
-                                        </TableRow>
-                                    </TableHeader>
-                                    <TableBody>
-                                        {data.notifications.data.map((notification) => {
-                                            const isUnViewed = notification.status.value === 'UNVIEWED';
-                                            return (
-                                                <TableRow key={notification.id}>
-                                                    {data.table.columns.map((column) => {
-                                                        switch (column.id) {
-                                                            case 'status':
-                                                                return (
-                                                                    <TableCell key={column.id} className="text-center">
-                                                                        {isUnViewed && (
-                                                                            <BadgeStatus variant="default"></BadgeStatus>
-                                                                        )}
-                                                                    </TableCell>
-                                                                );
-                                                            case 'title':
-                                                                return (
-                                                                    <TableCell
-                                                                        key={column.id}
-                                                                        className={cn(
-                                                                            'flex-initial max-w-[200px] lg:max-w-md truncate whitespace-nowrap',
-                                                                            isUnViewed && 'font-semibold',
-                                                                        )}
-                                                                    >
-                                                                        {notification.title}
-                                                                    </TableCell>
-                                                                );
-                                                            case 'type':
-                                                                return (
-                                                                    <TableCell
-                                                                        key={column.id}
-                                                                        className={cn(
-                                                                            'flex-initial whitespace-nowrap',
-                                                                            isUnViewed && 'font-semibold',
-                                                                        )}
-                                                                    >
-                                                                        {notification[column.id].label}
-                                                                    </TableCell>
-                                                                );
-                                                            case 'priority':
-                                                                return (
-                                                                    <TableCell key={column.id} className="flex-initial">
-                                                                        <Badge
-                                                                            variant={
-                                                                                Mappings.NotificationBadge
-                                                                                    .notificationBadgePriorityVariants[
-                                                                                    notification.priority.value
-                                                                                ]
-                                                                            }
-                                                                        >
-                                                                            {notification[column.id].label}
-                                                                        </Badge>
-                                                                    </TableCell>
-                                                                );
-                                                            case 'createdAt':
-                                                            case 'updatedAt':
-                                                                return (
-                                                                    <TableCell
-                                                                        key={column.id}
-                                                                        className={cn(
-                                                                            'whitespace-nowrap',
-                                                                            isUnViewed && 'font-semibold',
-                                                                        )}
-                                                                    >
-                                                                        {notification[column.id]}
-                                                                    </TableCell>
-                                                                );
-                                                            default:
-                                                                return null;
-                                                        }
-                                                    })}
-                                                    {data.table.actions && (
-                                                        <TableCell className="py-0">
-                                                            <Button asChild variant="link">
-                                                                <LinkComponent
-                                                                    href={notification.detailsUrl}
-                                                                    className="flex items-center justify-end gap-2"
-                                                                >
-                                                                    <ArrowRight className="h-4 w-4" />
-                                                                    {data.table.actions.label}
-                                                                </LinkComponent>
-                                                            </Button>
-                                                        </TableCell>
-                                                    )}
-                                                </TableRow>
-                                            );
-                                        })}
-                                    </TableBody>
-                                </Table>
+                                <DataList
+                                    data={data.notifications.data}
+                                    getRowKey={(notification) => notification.id}
+                                    getRowClassName={(notification) => {
+                                        return notification.status.value === 'UNVIEWED' ? '' : '';
+                                    }}
+                                    columns={columns}
+                                    actions={actions}
+                                />
 
                                 {data.pagination && (
                                     <Pagination

--- a/packages/blocks/ticket-list/src/frontend/TicketList.client.tsx
+++ b/packages/blocks/ticket-list/src/frontend/TicketList.client.tsx
@@ -7,16 +7,16 @@ import React, { useState, useTransition } from 'react';
 import { Mappings } from '@o2s/utils.frontend';
 
 import { ActionList } from '@o2s/ui/components/ActionList';
+import { DataList } from '@o2s/ui/components/DataList';
+import type { DataListColumnConfig } from '@o2s/ui/components/DataList';
 import { DynamicIcon } from '@o2s/ui/components/DynamicIcon';
 import { FiltersSection } from '@o2s/ui/components/Filters';
 import { NoResults } from '@o2s/ui/components/NoResults';
 import { Pagination } from '@o2s/ui/components/Pagination';
 
-import { Badge } from '@o2s/ui/elements/badge';
 import { Button } from '@o2s/ui/elements/button';
 import { LoadingOverlay } from '@o2s/ui/elements/loading-overlay';
 import { Separator } from '@o2s/ui/elements/separator';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@o2s/ui/elements/table';
 import { Typography } from '@o2s/ui/elements/typography';
 
 import { Model, Request } from '../api-harmonization/ticket-list.client';
@@ -56,6 +56,50 @@ export const TicketListPure: React.FC<TicketListPureProps> = ({ locale, accessTo
             setData(newData);
         });
     };
+
+    // Define columns configuration outside JSX for better readability
+    const columns = data.table.columns.map((column) => {
+        switch (column.id) {
+            case 'topic':
+                return {
+                    ...column,
+                    type: 'text',
+                    cellClassName: 'max-w-[200px] lg:max-w-md',
+                };
+            case 'status':
+                return {
+                    ...column,
+                    type: 'badge',
+                    variant: (value: string) =>
+                        Mappings.TicketBadge.ticketBadgeVariants[
+                            value as keyof typeof Mappings.TicketBadge.ticketBadgeVariants
+                        ],
+                };
+            case 'updatedAt':
+                return {
+                    ...column,
+                    type: 'date',
+                };
+            default:
+                return {
+                    ...column,
+                    type: 'text',
+                };
+        }
+    }) as DataListColumnConfig<Model.Ticket>[];
+    const actions = data.table.actions
+        ? {
+              ...data.table.actions,
+              render: (ticket: Model.Ticket) => (
+                  <Button asChild variant="link">
+                      <LinkComponent href={ticket.detailsUrl} className="flex items-center justify-end gap-2">
+                          <ArrowRight className="h-4 w-4" />
+                          {data.table.actions!.label}
+                      </LinkComponent>
+                  </Button>
+              ),
+          }
+        : undefined;
 
     return (
         <div className="w-full">
@@ -113,94 +157,7 @@ export const TicketListPure: React.FC<TicketListPureProps> = ({ locale, accessTo
                     <LoadingOverlay isActive={isPending}>
                         {data.tickets.data.length ? (
                             <div className="flex flex-col gap-6">
-                                <Table>
-                                    <TableHeader>
-                                        <TableRow>
-                                            {data.table.columns.map((column) => (
-                                                <TableHead
-                                                    key={column.id}
-                                                    className="py-3 px-4 text-sm font-medium text-muted-foreground"
-                                                >
-                                                    {column.title}
-                                                </TableHead>
-                                            ))}
-                                            {data.table.actions && (
-                                                <TableHead className="py-3 px-4 text-sm font-medium text-muted-foreground">
-                                                    {data.table.actions.title}
-                                                </TableHead>
-                                            )}
-                                        </TableRow>
-                                    </TableHeader>
-                                    <TableBody>
-                                        {data.tickets.data.map((ticket) => (
-                                            <TableRow key={ticket.id}>
-                                                {data.table.columns.map((column) => {
-                                                    switch (column.id) {
-                                                        case 'topic':
-                                                            return (
-                                                                <TableCell
-                                                                    key={column.id}
-                                                                    className="truncate whitespace-nowrap flex-initial max-w-[200px] lg:max-w-md"
-                                                                >
-                                                                    {ticket[column.id].label}
-                                                                </TableCell>
-                                                            );
-                                                        case 'type':
-                                                            return (
-                                                                <TableCell
-                                                                    key={column.id}
-                                                                    className="flex-initial whitespace-nowrap"
-                                                                >
-                                                                    {ticket[column.id].label}
-                                                                </TableCell>
-                                                            );
-                                                        case 'status':
-                                                            return (
-                                                                <TableCell
-                                                                    key={column.id}
-                                                                    className="flex-initial whitespace-nowrap"
-                                                                >
-                                                                    <Badge
-                                                                        variant={
-                                                                            Mappings.TicketBadge.ticketBadgeVariants[
-                                                                                ticket[column.id].value
-                                                                            ]
-                                                                        }
-                                                                    >
-                                                                        {ticket[column.id].label}
-                                                                    </Badge>
-                                                                </TableCell>
-                                                            );
-                                                        case 'updatedAt':
-                                                            return (
-                                                                <TableCell
-                                                                    key={column.id}
-                                                                    className="flex-initial whitespace-nowrap"
-                                                                >
-                                                                    {ticket[column.id]}
-                                                                </TableCell>
-                                                            );
-                                                        default:
-                                                            return null;
-                                                    }
-                                                })}
-                                                {data.table.actions && (
-                                                    <TableCell className="py-0">
-                                                        <Button asChild variant="link">
-                                                            <LinkComponent
-                                                                href={ticket.detailsUrl}
-                                                                className="flex items-center justify-end gap-2"
-                                                            >
-                                                                <ArrowRight className="h-4 w-4" />
-                                                                {data.table.actions.label}
-                                                            </LinkComponent>
-                                                        </Button>
-                                                    </TableCell>
-                                                )}
-                                            </TableRow>
-                                        ))}
-                                    </TableBody>
-                                </Table>
+                                <DataList data={data.tickets.data} columns={columns} actions={actions} />
 
                                 {data.pagination && (
                                     <Pagination

--- a/packages/ui/src/components/DataList/DataList.stories.tsx
+++ b/packages/ui/src/components/DataList/DataList.stories.tsx
@@ -1,0 +1,212 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { DataList } from './DataList';
+import type { DataListColumnConfig } from './DataList.types';
+
+const meta: Meta<typeof DataList> = {
+    title: 'Components/DataList',
+    component: DataList,
+    parameters: {
+        layout: 'padded',
+    },
+    tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DataList>;
+
+type Ticket = {
+    id: string;
+    topic: { label: string; value: string };
+    type: { label: string; value: string };
+    status: { label: string; value: string };
+    updatedAt: string;
+    detailsUrl: string;
+};
+
+const sampleTickets: Ticket[] = [
+    {
+        id: '1',
+        topic: { label: 'Login Issue', value: 'login-issue' },
+        type: { label: 'Technical', value: 'technical' },
+        status: { label: 'Open', value: 'open' },
+        updatedAt: '2024-01-15',
+        detailsUrl: '/tickets/1',
+    },
+    {
+        id: '2',
+        topic: { label: 'Billing Question', value: 'billing' },
+        type: { label: 'Billing', value: 'billing' },
+        status: { label: 'In Progress', value: 'in_progress' },
+        updatedAt: '2024-01-14',
+        detailsUrl: '/tickets/2',
+    },
+    {
+        id: '3',
+        topic: { label: 'Feature Request', value: 'feature' },
+        type: { label: 'General', value: 'general' },
+        status: { label: 'Closed', value: 'closed' },
+        updatedAt: '2024-01-13',
+        detailsUrl: '/tickets/3',
+    },
+];
+
+const ticketColumns: DataListColumnConfig<Ticket>[] = [
+    {
+        id: 'topic',
+        title: 'Topic',
+        type: 'text',
+        cellClassName: 'truncate max-w-[200px]',
+    },
+    {
+        id: 'type',
+        title: 'Type',
+        type: 'text',
+    },
+    {
+        id: 'status',
+        title: 'Status',
+        type: 'badge',
+        variant: (value: string) => {
+            switch (value) {
+                case 'open':
+                    return 'default';
+                case 'in_progress':
+                    return 'secondary';
+                case 'closed':
+                    return 'outline';
+                default:
+                    return 'default';
+            }
+        },
+    },
+    {
+        id: 'updatedAt',
+        title: 'Last Updated',
+        type: 'date',
+    },
+];
+
+type Order = {
+    id: string;
+    date: string;
+    status: { label: string; value: string };
+    total: { value: number; currency: string };
+};
+
+const sampleOrders: Order[] = [
+    {
+        id: '001',
+        date: '2024-01-15',
+        status: { label: 'Completed', value: 'completed' },
+        total: { value: 299.99, currency: 'USD' },
+    },
+    {
+        id: '002',
+        date: '2024-01-14',
+        status: { label: 'Pending', value: 'pending' },
+        total: { value: 149.5, currency: 'USD' },
+    },
+];
+
+const orderColumns: DataListColumnConfig<Order>[] = [
+    { id: 'id', title: 'Order ID', type: 'text' },
+    { id: 'date', title: 'Date', type: 'date' },
+    {
+        id: 'status',
+        title: 'Status',
+        type: 'badge',
+        variant: (value: string) => (value === 'completed' ? 'default' : 'secondary'),
+    },
+    {
+        id: 'total',
+        title: 'Total',
+        type: 'price',
+        headerClassName: 'text-right',
+        cellClassName: 'text-right',
+    },
+];
+
+export const BasicTextColumns: Story = {
+    args: {
+        data: sampleTickets,
+        columns: [
+            { id: 'topic', title: 'Topic', type: 'text' },
+            { id: 'type', title: 'Type', type: 'text' },
+            { id: 'updatedAt', title: 'Date', type: 'text' },
+        ],
+    },
+};
+
+export const WithBadges: Story = {
+    args: {
+        data: sampleTickets as Record<string, unknown>[],
+        columns: ticketColumns as DataListColumnConfig<Record<string, unknown>>[],
+    },
+};
+
+export const WithActions: Story = {
+    args: {
+        data: sampleTickets as Record<string, unknown>[],
+        columns: ticketColumns as DataListColumnConfig<Record<string, unknown>>[],
+        actions: {
+            title: 'Actions',
+            render: (_item) => <button className="text-blue-600 hover:underline">View Details →</button>,
+        },
+    },
+};
+
+export const WithPriceColumns: Story = {
+    args: {
+        data: sampleOrders as Record<string, unknown>[],
+        columns: orderColumns as DataListColumnConfig<Record<string, unknown>>[],
+    },
+};
+
+export const CustomCellRenderer: Story = {
+    args: {
+        data: sampleTickets as Record<string, unknown>[],
+        columns: [
+            {
+                id: 'topic',
+                title: 'Topic',
+                type: 'custom',
+                render: (value: unknown, item: Record<string, unknown>) => {
+                    const topicValue = value as { label: string };
+                    return (
+                        <div className="flex items-center gap-2">
+                            <span className="font-semibold">{topicValue.label}</span>
+                            <span className="text-xs text-gray-500">#{String(item.id)}</span>
+                        </div>
+                    );
+                },
+            },
+            { id: 'type', title: 'Type', type: 'text' },
+            {
+                id: 'status',
+                title: 'Status',
+                type: 'badge',
+                variant: (_value: string) => 'default' as const,
+            },
+        ] as DataListColumnConfig<Record<string, unknown>>[],
+    },
+};
+
+export const EmptyState: Story = {
+    args: {
+        data: [] as Record<string, unknown>[],
+        columns: ticketColumns as DataListColumnConfig<Record<string, unknown>>[],
+    },
+};
+
+export const WithCustomStyling: Story = {
+    args: {
+        data: sampleTickets as Record<string, unknown>[],
+        columns: ticketColumns.map((col) => ({
+            ...col,
+            headerClassName: 'bg-gray-100 font-bold',
+            cellClassName: 'py-4',
+        })) as DataListColumnConfig<Record<string, unknown>>[],
+        className: 'border-2 border-gray-300',
+    },
+};

--- a/packages/ui/src/components/DataList/DataList.tsx
+++ b/packages/ui/src/components/DataList/DataList.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+
+import { cn } from '@o2s/ui/lib/utils';
+
+import { Price } from '@o2s/ui/components/Price';
+
+import { Badge } from '@o2s/ui/elements/badge';
+import { BadgeStatus } from '@o2s/ui/elements/badge-status';
+import { Button } from '@o2s/ui/elements/button';
+import { Link } from '@o2s/ui/elements/link';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@o2s/ui/elements/table';
+
+import { DataListColumnConfig, DataListProps } from './DataList.types';
+
+/**
+ * Default cell renderer based on column type
+ */
+function renderCell<T>(value: Record<string, unknown>, item: T, column: DataListColumnConfig<T>): React.ReactNode {
+    if (value === null || value === undefined) {
+        return null;
+    }
+
+    if (column.type === 'custom') {
+        return column.render(value, item, column);
+    }
+
+    switch (column.type) {
+        case 'text': {
+            const displayField = column.displayField || 'label';
+            if (typeof value === 'object' && value !== null) {
+                return String(value[displayField]);
+            }
+            return String(value);
+        }
+
+        case 'badge': {
+            const badgeLabel = String(value[column.labelField || 'label']);
+            const badgeValue = String(value[column.valueField || 'value']);
+            const variant = column.variant ? column.variant(badgeValue) : 'default';
+
+            return <Badge variant={variant}>{badgeLabel}</Badge>;
+        }
+
+        case 'status':
+            return <BadgeStatus variant="default" />;
+
+        case 'date': {
+            const dateDisplayField = column.displayField || 'label';
+            if (typeof value === 'object' && value !== null) {
+                return String(value[dateDisplayField]);
+            }
+            return String(value);
+        }
+
+        case 'price': {
+            if (typeof value === 'object' && value !== null && 'value' in value) {
+                const priceValue = value as { value: number; currency?: string };
+                const currency = (
+                    column.config?.currencyKey ? String(item[column.config.currencyKey]) : priceValue.currency || 'USD'
+                ) as 'USD' | 'EUR' | 'GBP' | 'PLN';
+                return <Price price={{ value: priceValue.value, currency }} />;
+            }
+            if (typeof value === 'object' && value !== null) {
+                return <Price price={value as unknown as { value: number; currency: 'USD' | 'EUR' | 'GBP' | 'PLN' }} />;
+            }
+            return null;
+        }
+
+        case 'link': {
+            const linkDisplayField = column.displayField || 'label';
+            const linkLabel =
+                typeof value === 'object' && value !== null ? String(value[linkDisplayField]) : String(value);
+            const _href = column.config?.hrefKey ? String(item[column.config.hrefKey]) : '#';
+            const linkVariant = column.config?.variant ? column.config.variant : 'link';
+            const linkClassName = column.config?.className
+                ? column.config.className
+                : 'flex items-center justify-end gap-2';
+
+            if (linkVariant === 'link') {
+                return (
+                    <Link asChild>
+                        <Button variant="link" className={linkClassName}>
+                            {linkLabel}
+                        </Button>
+                    </Link>
+                );
+            }
+            return (
+                <Button variant={linkVariant} className={linkClassName}>
+                    {linkLabel}
+                </Button>
+            );
+        }
+
+        default:
+            return String(value);
+    }
+}
+
+/**
+ * DataList component - A reusable table component for displaying data
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function DataList<T extends Record<string, any>>({
+    data,
+    columns,
+    actions,
+    getRowKey,
+    className,
+    getRowClassName,
+}: DataListProps<T>) {
+    // Default row key extractor
+    const defaultGetRowKey = (item: T, index: number) => {
+        if ('id' in item) {
+            return String(item.id);
+        }
+        return index;
+    };
+
+    const rowKeyExtractor = getRowKey || defaultGetRowKey;
+
+    return (
+        <Table className={className}>
+            <TableHeader>
+                <TableRow>
+                    {columns.map((column) => (
+                        <TableHead
+                            key={String(column.id)}
+                            className={cn(
+                                'py-3 px-4 text-sm font-medium text-muted-foreground',
+                                column.headerClassName,
+                            )}
+                        >
+                            {column.title}
+                        </TableHead>
+                    ))}
+                    {actions && (
+                        <TableHead className="py-3 px-4 text-sm font-medium text-muted-foreground">
+                            {actions.title}
+                        </TableHead>
+                    )}
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {data.map((item, index) => {
+                    const rowKey = rowKeyExtractor(item, index);
+                    const rowClassName = getRowClassName ? getRowClassName(item) : undefined;
+
+                    return (
+                        <TableRow key={rowKey} className={rowClassName}>
+                            {columns.map((column) => {
+                                const value = item[column.id];
+                                const cellContent = renderCell(value, item, column);
+
+                                const cellClassName =
+                                    typeof column.cellClassName === 'string'
+                                        ? column.cellClassName
+                                        : column.cellClassName?.(item);
+
+                                const defaultClassName = column.type === 'text' ? 'truncate whitespace-nowrap' : '';
+
+                                return (
+                                    <TableCell key={String(column.id)} className={cn(defaultClassName, cellClassName)}>
+                                        {cellContent}
+                                    </TableCell>
+                                );
+                            })}
+                            {actions && (
+                                <TableCell className={cn('py-0', actions.cellClassName)}>
+                                    {actions.render ? actions.render(item) : null}
+                                </TableCell>
+                            )}
+                        </TableRow>
+                    );
+                })}
+            </TableBody>
+        </Table>
+    );
+}

--- a/packages/ui/src/components/DataList/DataList.types.ts
+++ b/packages/ui/src/components/DataList/DataList.types.ts
@@ -1,0 +1,154 @@
+import { Models } from '@o2s/framework/modules';
+import { ReactNode } from 'react';
+
+type DataTableColumn<T> = Models.DataTable.DataTableColumn<T>;
+type DataTableActions = Models.DataTable.DataTableActions;
+
+/**
+ * Column type definitions for DataList
+ */
+export type ColumnType = 'text' | 'badge' | 'date' | 'price' | 'link' | 'status' | 'custom';
+
+/**
+ * Common configuration shared by all column types
+ */
+interface DataListColumnCommonConfig<T> extends DataTableColumn<T> {
+    type: ColumnType;
+
+    /**
+     * Additional CSS classes for the header cell
+     */
+    headerClassName?: string;
+
+    /**
+     * Additional CSS classes for the body cell
+     */
+    cellClassName?: string | ((item: T) => string);
+}
+
+/**
+ * Text column configuration
+ */
+export interface DataListColumnTextConfig<T> extends DataListColumnCommonConfig<T> {
+    type: 'text';
+    displayField?: string;
+}
+
+/**
+ * Badge column configuration
+ */
+export interface DataListColumnBadgeConfig<T> extends DataListColumnCommonConfig<T> {
+    type: 'badge';
+    labelField?: string;
+    valueField?: string;
+    variant?: (value: string) => 'default' | 'destructive' | 'outline' | 'secondary';
+}
+
+/**
+ * Date column configuration
+ */
+export interface DataListColumnDateConfig<T> extends DataListColumnCommonConfig<T> {
+    type: 'date';
+    displayField?: string;
+    valueField?: string;
+}
+
+/**
+ * Price column configuration
+ */
+export interface DataListColumnPriceConfig<T> extends DataListColumnCommonConfig<T> {
+    type: 'price';
+    config?: {
+        currencyKey?: keyof T;
+    };
+}
+
+/**
+ * Link column configuration
+ */
+export interface DataListColumnLinkConfig<T> extends DataListColumnCommonConfig<T> {
+    type: 'link';
+    displayField?: string;
+    config?: {
+        hrefKey?: keyof T;
+        variant?: 'link' | 'default';
+        className?: string;
+    };
+}
+
+/**
+ * Status column configuration
+ */
+export interface DataListColumnStatusConfig<T> extends DataListColumnCommonConfig<T> {
+    type: 'status';
+}
+
+/**
+ * Custom column configuration with render function
+ */
+export interface DataListColumnCustomConfig<T> extends DataListColumnCommonConfig<T> {
+    type: 'custom';
+    render: (value: unknown, item: T, column: DataListColumnCustomConfig<T>) => ReactNode;
+}
+
+/**
+ * Discriminated union of all column configuration types
+ */
+export type DataListColumnConfig<T> =
+    | DataListColumnTextConfig<T>
+    | DataListColumnBadgeConfig<T>
+    | DataListColumnDateConfig<T>
+    | DataListColumnPriceConfig<T>
+    | DataListColumnLinkConfig<T>
+    | DataListColumnStatusConfig<T>
+    | DataListColumnCustomConfig<T>;
+
+/**
+ * Actions configuration with rendering options
+ */
+export interface DataListActionsConfig<T = unknown> extends DataTableActions {
+    /**
+     * Custom renderer for the actions cell
+     */
+    render?: (item: T) => ReactNode;
+
+    /**
+     * Additional CSS classes for the actions cell
+     */
+    cellClassName?: string;
+}
+
+/**
+ * Props for DataList component
+ */
+export interface DataListProps<T> {
+    /**
+     * Array of data items to display
+     */
+    data: T[];
+
+    /**
+     * Column configurations
+     */
+    columns: DataListColumnConfig<T>[];
+
+    /**
+     * Optional actions configuration
+     */
+    actions?: DataListActionsConfig<T>;
+
+    /**
+     * Optional row key extractor
+     */
+    getRowKey?: (item: T, index: number) => string | number;
+
+    /**
+     * Optional className for the table
+     */
+    className?: string;
+
+    /**
+     * Optional row className function
+     */
+    getRowClassName?: (item: T) => string;
+}

--- a/packages/ui/src/components/DataList/index.ts
+++ b/packages/ui/src/components/DataList/index.ts
@@ -1,0 +1,2 @@
+export { DataList } from './DataList';
+export type { DataListProps, DataListColumnConfig, DataListActionsConfig, ColumnType } from './DataList.types';


### PR DESCRIPTION
**What does this PR do?**

- [x] My bugfix
- [x] Feature: add reusable DataList and refactor list blocks

**Related Ticket(s)**

Notion: Data tables refactor (issue #305 )

**Key Changes**
DataList
 component in packages/ui/src/components/DataList/
 with typed column renderers (text, badge, date, price, link, badgeStatus, custom).
NEW DataList in:
packages/blocks/ticket-list/src/frontend/TicketList.client.tsx
packages/blocks/order-list/src/frontend/OrderList.client.tsx
packages/blocks/invoice-list/src/frontend/InvoiceList.client.tsx
packages/blocks/notification-list/src/frontend/NotificationList.client.tsx

[docs/dev] Storybook stories for DataList:
packages/ui/src/components/DataList/DataList.stories.tsx

**How to test**

Storybook:
- `npm run storybook`
- Open http://localhost:6006 → Components → DataList
Verify all stories render (Basic Text, With Badges, With Actions, With Price, Custom Cell Renderer, Empty State, With Custom Styling).

App test: 

Login with test users:
Verify list pages render with DataList:
- Tickets, Orders, Invoices, Notifications

**Feedback**
The monorepo is well structured with clear separation between /packages and /apps and setup was smooth after npm install. the workspace organization made sense once explored @o2s/ui, for shared components, and @o2s/blocks, for feature modules, but understanding the relationship between framework types and block-level API harmonization took a bit of time. Overall the project is well organized and maintainable. Prettier configuration was quite strict (good for consistency tho).

**Media (Loom or gif)**

