### PR TITLE
feat(ui): enhance component generator to create correct component structure

### DIFF
--- a/packages/ui/turbo/generators/config.ts
+++ b/packages/ui/turbo/generators/config.ts
@@ -13,8 +13,23 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
         actions: [
             {
                 type: 'add',
-                path: 'src/components/{{kebabCase name}}.tsx',
+                path: 'src/components/{{pascalCase name}}/{{pascalCase name}}.tsx',
                 templateFile: 'templates/component.hbs',
+            },
+            {
+                type: 'add',
+                path: 'src/components/{{pascalCase name}}/{{pascalCase name}}.types.ts',
+                templateFile: 'templates/types.hbs',
+            },
+            {
+                type: 'add',
+                path: 'src/components/{{pascalCase name}}/{{pascalCase name}}.stories.tsx',
+                templateFile: 'templates/stories.hbs',
+            },
+            {
+                type: 'add',
+                path: 'src/components/{{pascalCase name}}/index.ts',
+                templateFile: 'templates/index.hbs',
             },
         ],
     });

--- a/packages/ui/turbo/generators/templates/component.hbs
+++ b/packages/ui/turbo/generators/templates/component.hbs
@@ -1,13 +1,13 @@
-import { VariantProps, cva } from 'class-variance-authority';
 import React from 'react';
 
-export const {{ camelCase name }}Variants = cva('', {
-    variants: {},
-    defaultVariants: {},
-});
+import { cn } from '@o2s/ui/lib/utils';
 
-interface {{ pascalCase name }}Props extends VariantProps<typeof {{ camelCase name }}Variants> {}
+import { {{ pascalCase name }}Props } from './{{ pascalCase name }}.types';
 
-export const {{ pascalCase name }}: React.FC<Readonly<{{ pascalCase name }}Props>> = ({ ...props }) => {
-    return <div>{{ pascalCase name }}</div>;
-}
+export const {{ pascalCase name }}: React.FC<Readonly<{{ pascalCase name }}Props>> = ({ className, ...props }) => {
+    return (
+        <div className={cn('', className)} {...props}>
+            {{ pascalCase name }}
+        </div>
+    );
+};

--- a/packages/ui/turbo/generators/templates/index.hbs
+++ b/packages/ui/turbo/generators/templates/index.hbs
@@ -1,0 +1,3 @@
+export { {{ pascalCase name }} } from './{{ pascalCase name }}';
+export type { {{ pascalCase name }}Props } from './{{ pascalCase name }}.types';
+

--- a/packages/ui/turbo/generators/templates/stories.hbs
+++ b/packages/ui/turbo/generators/templates/stories.hbs
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { {{ pascalCase name }} } from './{{ pascalCase name }}';
+
+const meta: Meta<typeof {{ pascalCase name }}> = {
+    title: 'Components/{{ pascalCase name }}',
+    component: {{ pascalCase name }},
+    parameters: {
+        layout: 'fullscreen',
+    },
+    tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof {{ pascalCase name }}>;
+
+export const Default: Story = {
+    args: {
+        className: '{{ pascalCase name }}',
+    },
+};

--- a/packages/ui/turbo/generators/templates/types.hbs
+++ b/packages/ui/turbo/generators/templates/types.hbs
@@ -1,0 +1,1 @@
+export interface {{pascalCase name}}Props { className?: string; }


### PR DESCRIPTION
# Enhance UI Component Generator with full structure and files

**What does this PR do?**

- [x] Enhance UI Component Generator with full structure and files

**Key Changes**

- Enhanced the `ui-component` generator in `packages/ui/turbo/generators/` to create a complete component structure following the same pattern as existing components like `DataList`
- Generator now creates a dedicated folder for each component (`src/components/ComponentName/`) instead of placing files directly in the `components/` directory
- Added support for generating 4 files per component:
    - `ComponentName.tsx` - Main React component file
    - `ComponentName.types.ts` - TypeScript type definitions
    - `ComponentName.stories.tsx` - Storybook stories file
    - `index.ts` - Export file for the component

**Media (Loom or gif)**
<img width="447" height="725" alt="image" src="https://github.com/user-attachments/assets/461da651-8f7b-4f13-819e-2eccffdd9f3c" />
<img width="913" height="270" alt="image" src="https://github.com/user-attachments/assets/2a8f2a3e-567d-44f2-8aa1-b15827e0778a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced component generator to create organized folder-based structures with component files, type definitions, and Storybook stories instead of single files.
  * Added automatic Storybook story generation for new components.
  * Improved type support with dedicated types files for better code organization and reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->