### PR TITLE
feat: update page model and integration to support redirects

### DIFF
--- a/.changeset/all-islands-search.md
+++ b/.changeset/all-islands-search.md
@@ -1,0 +1,5 @@
+---
+'@o2s/integrations.mocked-dxp': minor
+---
+
+feat: added redirection for homepage dxp mock

--- a/.changeset/odd-stars-heal.md
+++ b/.changeset/odd-stars-heal.md
@@ -1,0 +1,7 @@
+---
+'@o2s/api-harmonization': minor
+'@o2s/framework': minor
+'@o2s/frontend': minor
+---
+
+feat: update page model and integration to support redirects

--- a/apps/api-harmonization/src/modules/page/page.mapper.ts
+++ b/apps/api-harmonization/src/modules/page/page.mapper.ts
@@ -31,6 +31,7 @@ export const mapPage = (
             },
             locales,
             theme: page.theme,
+            redirect: page.redirect,
         },
         data: {
             alternativeUrls,

--- a/apps/api-harmonization/src/modules/page/page.model.ts
+++ b/apps/api-harmonization/src/modules/page/page.model.ts
@@ -64,6 +64,7 @@ export class Metadata {
     seo!: Models.SEO.Page;
     locales!: string[];
     theme?: string;
+    redirect?: string;
 }
 
 export class Breadcrumb {

--- a/apps/frontend/src/app/[locale]/[[...slug]]/page.tsx
+++ b/apps/frontend/src/app/[locale]/[[...slug]]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import { setRequestLocale } from 'next-intl/server';
 import { headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import React from 'react';
 
 import { GlobalProvider } from '@o2s/ui/providers/GlobalProvider';
@@ -95,6 +95,10 @@ export default async function Page({ params }: Props) {
             { 'x-locale': locale },
             session?.accessToken,
         );
+
+        if (meta.redirect) {
+            redirect(`/${locale}${meta.redirect}`);
+        }
 
         if (session?.user && session?.error === 'RefreshTokenError') {
             return await signIn();

--- a/package-lock.json
+++ b/package-lock.json
@@ -51545,7 +51545,7 @@
             }
         },
         "packages/cli/create-o2s-app": {
-            "version": "2.0.0",
+            "version": "3.0.0",
             "license": "MIT",
             "dependencies": {
                 "@o2s/telemetry": "^1.2.1",
@@ -51599,7 +51599,8 @@
             "license": "MIT",
             "dependencies": {
                 "@o2s/framework": "*",
-                "@o2s/integrations.mocked": "*"
+                "@o2s/integrations.mocked": "*",
+                "@o2s/integrations.mocked-dxp": "*"
             },
             "devDependencies": {
                 "@o2s/eslint-config": "*",
@@ -51963,7 +51964,7 @@
         },
         "packages/integrations/mocked-dxp": {
             "name": "@o2s/integrations.mocked-dxp",
-            "version": "0.0.1",
+            "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
                 "@o2s/framework": "*",

--- a/packages/framework/src/modules/cms/models/page.model.ts
+++ b/packages/framework/src/modules/cms/models/page.model.ts
@@ -24,6 +24,7 @@ export class Page {
     /** Role-based access control (e.g., ['ORG_USER', 'ORG_ADMIN']) */
     roles?: string[];
     theme?: string;
+    redirect?: string;
 }
 
 export abstract class Template {

--- a/packages/integrations/mocked-dxp/src/modules/cms/mappers/mocks/pages/home.page.ts
+++ b/packages/integrations/mocked-dxp/src/modules/cms/mappers/mocks/pages/home.page.ts
@@ -41,6 +41,7 @@ export const PAGE_HOME_EN: CMS.Model.Page.Page = {
         },
     },
     hasOwnTitle: true,
+    redirect: '/personal',
     template: {
         __typename: 'OneColumnTemplate',
         slots: {
@@ -92,6 +93,7 @@ export const PAGE_HOME_DE: CMS.Model.Page.Page = {
         },
     },
     hasOwnTitle: false,
+    redirect: '/personlich',
     template: {
         __typename: 'OneColumnTemplate',
         slots: {
@@ -143,6 +145,7 @@ export const PAGE_HOME_PL: CMS.Model.Page.Page = {
         },
     },
     hasOwnTitle: false,
+    redirect: '/indywidualny',
     template: {
         __typename: 'OneColumnTemplate',
         slots: {


### PR DESCRIPTION
 **What does this PR do?**

  - [x] Add page-level redirect support to CMS Page model

  **Related Ticket(s)**

  - Closes #776

  **Key Changes**

  - Added optional `redirect` field to the CMS Page model in `@o2s/framework`
  (`packages/framework/src/modules/cms/models/page.model.ts`)
  - Added `redirect` to API harmonization `Metadata` model and page mapper to pass it through from CMS to frontend
  - Added redirect logic in frontend `page.tsx` — if `meta.redirect` is present, performs a Next.js redirect to
  `/${locale}${meta.redirect}`
  - Configured mocked-dxp home page (`/`) to redirect to `/personal` (EN), `/personlich` (DE), `/indywidualny` (PL) — matching
  dxp-starter-kit behavior

  **How to test**

  1. Switch `configs/integrations` to use `@o2s/integrations.mocked-dxp` for `cms`, `articles`, and `search` modules
  2. Run `npm install` and `npm run dev`
  3. Navigate to `localhost:3000/en` — should redirect to `localhost:3000/en/personal`
  4. Navigate to `localhost:3000/pl` — should redirect to `localhost:3000/pl/indywidualny`
  5. Navigate to `localhost:3000/de` — should redirect to `localhost:3000/de/personlich`
  6. Verify subpages (e.g. `/en/personal/accounts`) still work normally without redirect

  **Media (Loom or gif)**

  - N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added page redirect functionality with locale-aware support. Pages can now define custom redirects, with the homepage configured to redirect to language-specific destinations for improved user navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->