### PR TITLE
fix(cli): remove @o2s/framework refs from .storybook/main.ts during scaffold

### DIFF
--- a/packages/cli/create-o2s-app/src/scaffold/index.ts
+++ b/packages/cli/create-o2s-app/src/scaffold/index.ts
@@ -10,6 +10,7 @@ import { transformIntegrationConfigs } from './transform-integration-configs';
 import { transformRootPackageJson } from './transform-package-json';
 import { transformPageModel } from './transform-page-model';
 import { transformRenderBlocks } from './transform-render-blocks';
+import { transformStorybookConfig } from './transform-storybook-config';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
@@ -74,6 +75,7 @@ export const scaffold = async (
         transformRenderBlocks(targetDir, selectedBlocks),
         transformPageModel(targetDir, selectedBlocks),
         transformAppsPackageJson(targetDir, selectedBlocks, selectedIntegrations),
+        transformStorybookConfig(targetDir),
     ]);
 
     // Step 5: Clean up root package.json (remove workspace entries for deleted dirs)

--- a/packages/cli/create-o2s-app/src/scaffold/transform-storybook-config.ts
+++ b/packages/cli/create-o2s-app/src/scaffold/transform-storybook-config.ts
@@ -18,5 +18,7 @@ export const transformStorybookConfig = async (projectDir: string): Promise<void
         return !FRAMEWORK_REFERENCE_REGEX.test(line);
     });
 
+    if (filteredLines.length === lines.length) return;
+
     await fs.writeFile(filePath, filteredLines.join('\n'), 'utf-8');
 };

--- a/packages/cli/create-o2s-app/src/scaffold/transform-storybook-config.ts
+++ b/packages/cli/create-o2s-app/src/scaffold/transform-storybook-config.ts
@@ -1,0 +1,22 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+const FILE_PATH = '.storybook/main.ts';
+
+// Regex matches lines containing '@o2s/framework' in optimizeDeps.include or resolve.alias
+const FRAMEWORK_REFERENCE_REGEX = /['"]@o2s\/framework\//;
+
+export const transformStorybookConfig = async (projectDir: string): Promise<void> => {
+    const filePath = path.join(projectDir, FILE_PATH);
+
+    if (!(await fs.pathExists(filePath))) return;
+
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.split('\n');
+
+    const filteredLines = lines.filter((line) => {
+        return !FRAMEWORK_REFERENCE_REGEX.test(line);
+    });
+
+    await fs.writeFile(filePath, filteredLines.join('\n'), 'utf-8');
+};


### PR DESCRIPTION
## Summary

Fixes #836

After scaffolding with `create-o2s-app`, Storybook fails because `.storybook/main.ts` still contains references to `@o2s/framework/sdk` and `@o2s/framework/modules` in both `resolve.alias` (lines 92-93) and `optimizeDeps.include` (lines 76-77), even though `packages/framework/` is removed during scaffolding (listed in `ALWAYS_REMOVE_DIRS`).

## Changes

- **New file:** `packages/cli/create-o2s-app/src/scaffold/transform-storybook-config.ts` — a transform that filters out lines containing `@o2s/framework/` references from `.storybook/main.ts`
- **Modified:** `packages/cli/create-o2s-app/src/scaffold/index.ts` — added `transformStorybookConfig` to the Step 4 parallel transform batch

The transform follows the same regex-based line-filtering pattern used by existing transforms (e.g., `transform-app-module.ts`).

## Test plan

- [ ] Run `npx create-o2s-app` and scaffold a project
- [ ] Verify `.storybook/main.ts` in the scaffolded project does not contain `@o2s/framework` references
- [ ] Verify Storybook starts correctly with `npm run storybook`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project scaffolding now automatically updates Storybook configuration during creation, removing legacy framework-specific references to ensure a cleaner, compatible setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->