### PR TITLE
fix(cli): remove @o2s/framework references from Storybook config during scaffold

### DIFF
--- a/packages/cli/create-o2s-app/src/scaffold/cleanup.ts
+++ b/packages/cli/create-o2s-app/src/scaffold/cleanup.ts
@@ -2,6 +2,28 @@ import { ALWAYS_REMOVE_DIRS, ALWAYS_REMOVE_FILES } from '../constants';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
+/**
+ * Removes @o2s/framework references from .storybook/main.ts after scaffolding.
+ * The packages/framework directory is always removed, so these aliases and
+ * optimizeDeps entries would cause Storybook to fail.
+ */
+const cleanStorybookConfig = async (projectDir: string): Promise<void> => {
+    const configPath = path.join(projectDir, '.storybook', 'main.ts');
+    if (!(await fs.pathExists(configPath))) return;
+
+    let content = await fs.readFile(configPath, 'utf-8');
+
+    // Remove @o2s/framework lines from optimizeDeps.include
+    content = content.replace(/\s*'@o2s\/framework\/modules',?\n?/g, '');
+    content = content.replace(/\s*'@o2s\/framework\/sdk',?\n?/g, '');
+
+    // Remove @o2s/framework alias lines from resolve.alias
+    content = content.replace(/\s*'@o2s\/framework\/sdk':.*\n/g, '');
+    content = content.replace(/\s*'@o2s\/framework\/modules':.*\n/g, '');
+
+    await fs.writeFile(configPath, content, 'utf-8');
+};
+
 export const cleanupProject = async (projectDir: string): Promise<void> => {
     console.log('Organizing project structure...');
 
@@ -18,4 +40,7 @@ export const cleanupProject = async (projectDir: string): Promise<void> => {
             await fs.remove(fullPath);
         }
     }
+
+    // Clean storybook config after removing framework directory
+    await cleanStorybookConfig(projectDir);
 };


### PR DESCRIPTION
Fixes #836

After scaffolding with `create-o2s-app`, Storybook fails because `.storybook/main.ts` contains resolve aliases and `optimizeDeps` entries pointing to `packages/framework/` paths that no longer exist (removed by `ALWAYS_REMOVE_DIRS`).

## Changes

Added `cleanStorybookConfig()` to `cleanup.ts` that strips:
- `@o2s/framework/modules` and `@o2s/framework/sdk` from `optimizeDeps.include`
- `@o2s/framework/sdk` and `@o2s/framework/modules` alias entries from `resolve.alias`

Runs automatically after directory cleanup, so the Storybook config is consistent with the scaffolded project structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved project scaffolding cleanup to properly remove outdated framework references from Storybook configuration, ensuring generated projects maintain valid configurations when removing framework packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->