### PR TITLE
fix(ui): [Bug] Rich text nested paragraph causes Next.js hydration er…

### DIFF
--- a/.changeset/sad-lies-kick.md
+++ b/.changeset/sad-lies-kick.md
@@ -1,0 +1,5 @@
+---
+'@o2s/ui': patch
+---
+
+fix(ui): use div instead of p tag in RichText paragraph override to prevent hydration errors from nested block-level elements

--- a/packages/ui/src/components/Content/RichText/RichText.tsx
+++ b/packages/ui/src/components/Content/RichText/RichText.tsx
@@ -135,6 +135,7 @@ export const RichText: FC<Readonly<RichTextProps>> = ({
             component: TypographyComp,
             props: {
                 variant: baseFontSize,
+                tag: 'div',
                 className: cn('[&:not(:first-child)]:mt-6', className),
             },
         },


### PR DESCRIPTION
Fixes #779

## Problem

The RichText component's `p` override renders paragraphs as `<p>` elements via TypographyComp. When content contains block-level descendants (e.g. `<div>` from ImgComp or nested `<p>` from HTML), this produces invalid HTML nesting and triggers Next.js hydration errors:

- `In HTML, <p> cannot be a descendant of <p>`
- `Hydration failed because... Invalid HTML tag nesting`

## Solution

Changed the `p` override in RichText to use `tag: 'div'` instead of the default `'p'`. This allows block-level descendants while preserving visual styling (Typography applies styles via variant, not tag).

## Changes

- `packages/ui/src/components/RichText/RichText.tsx` — added `tag: 'div'` to paragraph override props

## Changeset

Included as `@o2s/ui` patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed hydration errors in RichText component that could occur with certain content structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->