### PR TITLE
feat: sync list filters with url params

### DIFF
--- a/.changeset/swift-lists-share.md
+++ b/.changeset/swift-lists-share.md
@@ -1,0 +1,9 @@
+---
+'@o2s/blocks.invoice-list': minor
+'@o2s/blocks.notification-list': minor
+'@o2s/blocks.order-list': minor
+'@o2s/blocks.product-list': minor
+'@o2s/blocks.ticket-list': minor
+---
+
+Add URL query parameter synchronization for list block filters, pagination, and view mode.

--- a/packages/blocks/billing/invoice-list/src/frontend/InvoiceList.client.tsx
+++ b/packages/blocks/billing/invoice-list/src/frontend/InvoiceList.client.tsx
@@ -3,11 +3,14 @@
 import { IntlMessageFormat } from 'intl-messageformat';
 import { Download } from 'lucide-react';
 import { useLocale } from 'next-intl';
+import { createNavigation } from 'next-intl/navigation';
+import { useSearchParams } from 'next/navigation';
 import React, { useState, useTransition } from 'react';
 
 import { Mappings, Utils } from '@o2s/utils.frontend';
 
 import { toast } from '@o2s/ui/hooks/use-toast';
+import { useUrlFilters } from '@o2s/ui/hooks/use-url-filters';
 
 import { useGlobalContext } from '@o2s/ui/providers/GlobalProvider';
 
@@ -28,25 +31,43 @@ import { sdk } from '../sdk';
 import { InvoiceListPureProps } from './InvoiceList.types';
 
 export const InvoiceListPure: React.FC<InvoiceListPureProps> = ({ locale, accessToken, routing, ...component }) => {
+    const { usePathname, useRouter } = createNavigation(routing);
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const { labels } = useGlobalContext();
     const currentLocale = useLocale();
 
-    const initialFilters: Request.GetInvoiceListBlockQuery = {
-        id: component.id,
-        offset: 0,
-        limit: component.pagination?.limit || 5,
-        search: '',
-    };
+    const initialFilters = React.useMemo<Request.GetInvoiceListBlockQuery>(
+        () => ({
+            id: component.id,
+            offset: 0,
+            limit: component.pagination?.limit || 5,
+            search: '',
+        }),
+        [component.id, component.pagination?.limit],
+    );
 
     const initialData = component.invoices.data;
 
     // Extract initial viewMode from filters if available
     const initialViewMode =
         component.filters?.items?.find((item) => item.__typename === 'FilterViewModeToggle')?.value || 'list';
+    const filterNamespace = component.id || 'invoice-list';
 
     const [data, setData] = useState(component);
-    const [filters, setFilters] = useState(initialFilters);
-    const [viewMode, setViewMode] = useState<'list' | 'grid'>(initialViewMode);
+    const { filters, setFilters, viewMode, setViewMode, hasUrlFilters } = useUrlFilters<
+        Request.GetInvoiceListBlockQuery,
+        'list' | 'grid'
+    >({
+        namespace: filterNamespace,
+        initialFilters,
+        filterKeys: ['id', 'offset', 'limit', 'dateFrom', 'dateTo', 'search'],
+        initialViewMode: initialViewMode as 'list' | 'grid',
+        searchParams,
+        pathname,
+        onUrlChange: (url) => router.replace(url, { scroll: false }),
+    });
     const [selectedRows, setSelectedRows] = useState<Set<string | number>>(new Set());
     const [isPending, startTransition] = useTransition();
 
@@ -85,6 +106,13 @@ export const InvoiceListPure: React.FC<InvoiceListPureProps> = ({ locale, access
             }
         });
     };
+
+    React.useEffect(() => {
+        if (hasUrlFilters) {
+            handleFilter(filters);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const handleDownload = async (id: string) => {
         try {

--- a/packages/blocks/notifications/notification-list/src/frontend/NotificationList.client.tsx
+++ b/packages/blocks/notifications/notification-list/src/frontend/NotificationList.client.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowRight } from 'lucide-react';
 import { createNavigation } from 'next-intl/navigation';
+import { useSearchParams } from 'next/navigation';
 import React, { useState, useTransition } from 'react';
 
 import { Mappings } from '@o2s/utils.frontend';
@@ -9,6 +10,7 @@ import { Mappings } from '@o2s/utils.frontend';
 import { cn } from '@o2s/ui/lib/utils';
 
 import { toast } from '@o2s/ui/hooks/use-toast';
+import { useUrlFilters } from '@o2s/ui/hooks/use-url-filters';
 
 import { useGlobalContext } from '@o2s/ui/providers/GlobalProvider';
 
@@ -34,24 +36,40 @@ export const NotificationListPure: React.FC<NotificationListPureProps> = ({
     routing,
     ...component
 }) => {
-    const { Link: LinkComponent } = createNavigation(routing);
+    const { Link: LinkComponent, usePathname, useRouter } = createNavigation(routing);
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const { labels } = useGlobalContext();
 
-    const initialFilters: Request.GetNotificationListBlockQuery = {
-        id: component.id,
-        offset: 0,
-        limit: component.pagination?.limit || 5,
-    };
+    const initialFilters = React.useMemo<Request.GetNotificationListBlockQuery>(
+        () => ({
+            id: component.id,
+            offset: 0,
+            limit: component.pagination?.limit || 5,
+        }),
+        [component.id, component.pagination?.limit],
+    );
 
     const initialData = component.notifications.data;
 
     // Extract initial viewMode from filters if available
     const initialViewMode =
         component.filters?.items?.find((item) => item.__typename === 'FilterViewModeToggle')?.value || 'list';
+    const filterNamespace = component.id || 'notification-list';
 
     const [data, setData] = useState<Model.NotificationListBlock>(component);
-    const [filters, setFilters] = useState(initialFilters);
-    const [viewMode, setViewMode] = useState<'list' | 'grid'>(initialViewMode);
+    const { filters, setFilters, viewMode, setViewMode, hasUrlFilters } = useUrlFilters<
+        Request.GetNotificationListBlockQuery,
+        'list' | 'grid'
+    >({
+        namespace: filterNamespace,
+        initialFilters,
+        initialViewMode: initialViewMode as 'list' | 'grid',
+        searchParams,
+        pathname,
+        onUrlChange: (url) => router.replace(url, { scroll: false }),
+    });
     const [selectedRows, setSelectedRows] = useState<Set<string | number>>(new Set());
     const [isPending, startTransition] = useTransition();
 
@@ -95,6 +113,13 @@ export const NotificationListPure: React.FC<NotificationListPureProps> = ({
             }
         });
     };
+
+    React.useEffect(() => {
+        if (hasUrlFilters) {
+            handleFilter(filters);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // Define columns configuration outside JSX for better readability
     const columns = data.table.columns.map((column) => {

--- a/packages/blocks/orders/order-list/src/frontend/OrderList.client.tsx
+++ b/packages/blocks/orders/order-list/src/frontend/OrderList.client.tsx
@@ -2,11 +2,13 @@
 
 import { ArrowRight, IterationCw, MoreVertical } from 'lucide-react';
 import { createNavigation } from 'next-intl/navigation';
+import { useSearchParams } from 'next/navigation';
 import React, { useState, useTransition } from 'react';
 
 import { Mappings } from '@o2s/utils.frontend';
 
 import { toast } from '@o2s/ui/hooks/use-toast';
+import { useUrlFilters } from '@o2s/ui/hooks/use-url-filters';
 
 import { useGlobalContext } from '@o2s/ui/providers/GlobalProvider';
 
@@ -33,14 +35,20 @@ import { sdk } from '../sdk';
 import { OrderListPureProps } from './OrderList.types';
 
 export const OrderListPure: React.FC<OrderListPureProps> = ({ locale, accessToken, routing, ...component }) => {
-    const { Link: LinkComponent } = createNavigation(routing);
+    const { Link: LinkComponent, usePathname, useRouter } = createNavigation(routing);
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const { labels } = useGlobalContext();
 
-    const initialFilters: Request.GetOrderListBlockQuery = {
-        id: component.id,
-        offset: 0,
-        limit: component.pagination?.limit || 5,
-    };
+    const initialFilters = React.useMemo<Request.GetOrderListBlockQuery>(
+        () => ({
+            id: component.id,
+            offset: 0,
+            limit: component.pagination?.limit || 5,
+        }),
+        [component.id, component.pagination?.limit],
+    );
 
     const initialData = component.orders.data;
 
@@ -48,10 +56,20 @@ export const OrderListPure: React.FC<OrderListPureProps> = ({ locale, accessToke
         const value = component.filters?.items?.find((item) => item.__typename === 'FilterViewModeToggle')?.value;
         return value === 'grid' ? 'grid' : 'list';
     })();
+    const filterNamespace = component.id || 'order-list';
 
     const [data, setData] = useState<Model.OrderListBlock>(component);
-    const [filters, setFilters] = useState(initialFilters);
-    const [viewMode, setViewMode] = useState<'list' | 'grid'>(initialViewMode);
+    const { filters, setFilters, viewMode, setViewMode, hasUrlFilters } = useUrlFilters<
+        Request.GetOrderListBlockQuery,
+        'list' | 'grid'
+    >({
+        namespace: filterNamespace,
+        initialFilters,
+        initialViewMode,
+        searchParams,
+        pathname,
+        onUrlChange: (url) => router.replace(url, { scroll: false }),
+    });
     const [selectedRows, setSelectedRows] = useState<Set<string | number>>(new Set());
 
     const [isPending, startTransition] = useTransition();
@@ -91,6 +109,13 @@ export const OrderListPure: React.FC<OrderListPureProps> = ({ locale, accessToke
             }
         });
     };
+
+    React.useEffect(() => {
+        if (hasUrlFilters) {
+            handleFilter(filters);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // Define columns configuration outside JSX for better readability
     const columns = data.table.columns.map((column) => {

--- a/packages/blocks/products/product-list/src/frontend/ProductList.client.tsx
+++ b/packages/blocks/products/product-list/src/frontend/ProductList.client.tsx
@@ -3,6 +3,7 @@
 import { eventBus } from '@o2s/ui/event-bus';
 import { ArrowRight, ShoppingCart } from 'lucide-react';
 import { createNavigation } from 'next-intl/navigation';
+import { useSearchParams } from 'next/navigation';
 import React, { useCallback, useState, useTransition } from 'react';
 
 import { Utils } from '@o2s/utils.frontend';
@@ -10,6 +11,7 @@ import { Utils } from '@o2s/utils.frontend';
 import type { Models } from '@o2s/framework/modules';
 
 import { toast } from '@o2s/ui/hooks/use-toast';
+import { useUrlFilters } from '@o2s/ui/hooks/use-url-filters';
 
 import { ProductCard, ProductCardBadge } from '@o2s/ui/components/Cards/ProductCard';
 import { DataList } from '@o2s/ui/components/Data/DataList';
@@ -23,31 +25,47 @@ import { LoadingOverlay } from '@o2s/ui/elements/loading-overlay';
 import { Separator } from '@o2s/ui/elements/separator';
 import { ToastAction } from '@o2s/ui/elements/toast';
 
-import type { Model } from '../api-harmonization/product-list.client';
+import type { Model, Request } from '../api-harmonization/product-list.client';
 import { sdk } from '../sdk';
 
 import { ProductListPureProps } from './ProductList.types';
 
 export const ProductListPure: React.FC<ProductListPureProps> = ({ locale, accessToken, routing, ...component }) => {
-    const { Link: LinkComponent, useRouter } = createNavigation(routing);
+    const { Link: LinkComponent, usePathname, useRouter } = createNavigation(routing);
     const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const initialProducts = component.products?.data ?? [];
     const canRender = !!component.table?.columns && !!component.noResults && !!component.labels;
 
-    const initialFilters = {
-        id: component.id,
-        offset: 0,
-        limit: component.pagination?.limit || 12,
-    };
+    const initialFilters = React.useMemo<Request.GetProductListBlockQuery>(
+        () => ({
+            id: component.id,
+            offset: 0,
+            limit: component.pagination?.limit || 12,
+        }),
+        [component.id, component.pagination?.limit],
+    );
 
     const initialData = initialProducts;
 
     const initialViewMode =
         component.filters?.items.find((item) => item.__typename === 'FilterViewModeToggle')?.value || 'grid';
+    const filterNamespace = component.id || 'product-list';
 
     const [data, setData] = useState(component);
-    const [filters, setFilters] = useState(initialFilters);
-    const [viewMode, setViewMode] = useState<'grid' | 'list'>(initialViewMode);
+    const { filters, setFilters, viewMode, setViewMode, hasUrlFilters } = useUrlFilters<
+        Request.GetProductListBlockQuery,
+        'grid' | 'list'
+    >({
+        namespace: filterNamespace,
+        initialFilters,
+        filterKeys: ['id', 'offset', 'limit', 'type', 'category', 'sort'],
+        initialViewMode: initialViewMode as 'grid' | 'list',
+        searchParams,
+        pathname,
+        onUrlChange: (url) => router.replace(url, { scroll: false }),
+    });
     const [selectedRows, setSelectedRows] = useState<Set<string | number>>(new Set());
 
     const [isPending, startTransition] = useTransition();
@@ -123,6 +141,13 @@ export const ProductListPure: React.FC<ProductListPureProps> = ({ locale, access
             setSelectedRows(new Set());
         });
     };
+
+    React.useEffect(() => {
+        if (hasUrlFilters) {
+            handleFilter(filters);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // Define table columns configuration
     const columns = (data.table?.columns ?? []).map((column) => {

--- a/packages/blocks/support/ticket-list/src/frontend/TicketList.client.tsx
+++ b/packages/blocks/support/ticket-list/src/frontend/TicketList.client.tsx
@@ -3,11 +3,13 @@
 import { LivePreview } from '@o2s/configs.integrations/live-preview';
 import { ArrowRight } from 'lucide-react';
 import { createNavigation } from 'next-intl/navigation';
+import { useSearchParams } from 'next/navigation';
 import React, { useState, useTransition } from 'react';
 
 import { Mappings } from '@o2s/utils.frontend';
 
 import { toast } from '@o2s/ui/hooks/use-toast';
+import { useUrlFilters } from '@o2s/ui/hooks/use-url-filters';
 
 import { useGlobalContext } from '@o2s/ui/providers/GlobalProvider';
 
@@ -30,27 +32,43 @@ import { sdk } from '../sdk';
 import { Action, TicketListPureProps } from './TicketList.types';
 
 export const TicketListPure: React.FC<TicketListPureProps> = ({ locale, accessToken, routing, meta, ...component }) => {
-    const { Link: LinkComponent } = createNavigation(routing);
+    const { Link: LinkComponent, usePathname, useRouter } = createNavigation(routing);
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const inspector = LivePreview.useInspector();
     const { labels } = useGlobalContext();
 
-    const initialFilters: Request.GetTicketListBlockQuery = {
-        id: component.id,
-        offset: 0,
-        limit: component.pagination?.limit || 5,
-        search: '',
-        priority: '',
-    };
+    const initialFilters = React.useMemo<Request.GetTicketListBlockQuery>(
+        () => ({
+            id: component.id,
+            offset: 0,
+            limit: component.pagination?.limit || 5,
+            search: '',
+            priority: '',
+        }),
+        [component.id, component.pagination?.limit],
+    );
 
     const initialData = component.tickets.data;
 
     // Extract initial viewMode from filters if available
     const initialViewMode =
         component.filters?.items.find((item) => item.__typename === 'FilterViewModeToggle')?.value || 'list';
+    const filterNamespace = component.id || 'ticket-list';
 
     const [data, setData] = useState<Model.TicketListBlock>(component);
-    const [filters, setFilters] = useState(initialFilters);
-    const [viewMode, setViewMode] = useState<'list' | 'grid'>(initialViewMode);
+    const { filters, setFilters, viewMode, setViewMode, hasUrlFilters } = useUrlFilters<
+        Request.GetTicketListBlockQuery,
+        'list' | 'grid'
+    >({
+        namespace: filterNamespace,
+        initialFilters,
+        initialViewMode: initialViewMode as 'list' | 'grid',
+        searchParams,
+        pathname,
+        onUrlChange: (url) => router.replace(url, { scroll: false }),
+    });
     const [selectedRows, setSelectedRows] = useState<Set<string | number>>(new Set());
 
     const [isPending, startTransition] = useTransition();
@@ -89,6 +107,13 @@ export const TicketListPure: React.FC<TicketListPureProps> = ({ locale, accessTo
             }
         });
     };
+
+    React.useEffect(() => {
+        if (hasUrlFilters) {
+            handleFilter(filters);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const variantConfig: Array<{ variant: Action['variant']; className: string }> = [
         { variant: 'default', className: 'no-underline hover:no-underline' },

--- a/packages/ui/src/hooks/use-url-filters.spec.ts
+++ b/packages/ui/src/hooks/use-url-filters.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseUrlFilters, parseUrlViewMode, serializeUrlFilters } from './use-url-filters';
+
+describe('use-url-filters utilities', () => {
+    it('parses namespaced filters and 1-based page values from URL params', () => {
+        const initialFilters = {
+            id: 'ticket-list',
+            offset: 0,
+            limit: 5,
+            search: '',
+            status: [] as string[],
+        };
+        const searchParams = new URLSearchParams(
+            'tickets_search=refund&tickets_status=open&tickets_status=pending&tickets_page=3&tickets_view=grid',
+        );
+
+        expect(parseUrlFilters({ namespace: 'tickets', initialFilters, searchParams })).toEqual({
+            id: 'ticket-list',
+            limit: 5,
+            offset: 10,
+            search: 'refund',
+            status: ['open', 'pending'],
+        });
+        expect(parseUrlViewMode({ namespace: 'tickets', initialViewMode: 'list', searchParams })).toBe('grid');
+    });
+
+    it('serializes only non-default values and preserves unrelated query params', () => {
+        const initialFilters = {
+            id: 'ticket-list',
+            offset: 0,
+            limit: 5,
+            search: '',
+            status: [] as string[],
+        };
+        const searchParams = new URLSearchParams('locale=en&orders_page=2&tickets_search=old');
+
+        const result = serializeUrlFilters({
+            namespace: 'tickets',
+            initialFilters,
+            filters: {
+                ...initialFilters,
+                offset: 5,
+                search: 'refund',
+                status: ['open', 'pending'],
+            },
+            viewMode: 'grid',
+            defaultViewMode: 'list',
+            searchParams,
+        });
+
+        expect(result).toBe(
+            [
+                'locale=en',
+                'orders_page=2',
+                'tickets_page=2',
+                'tickets_search=refund',
+                'tickets_status=open',
+                'tickets_status=pending',
+                'tickets_view=grid',
+            ].join('&'),
+        );
+    });
+
+    it('removes namespaced params when filters return to defaults', () => {
+        const initialFilters = {
+            id: 'product-list',
+            offset: 0,
+            limit: 12,
+            category: '',
+        };
+        const searchParams = new URLSearchParams('products_page=4&products_category=coffee&keep=true');
+
+        const result = serializeUrlFilters({
+            namespace: 'products',
+            initialFilters,
+            filters: initialFilters,
+            viewMode: 'list',
+            defaultViewMode: 'list',
+            searchParams,
+        });
+
+        expect(result).toBe('keep=true');
+    });
+
+    it('parses optional filter keys that are not present in initial values', () => {
+        const initialFilters = {
+            id: 'product-list',
+            offset: 0,
+            limit: 12,
+        };
+        const searchParams = new URLSearchParams('products_category=coffee&products_sort=name');
+
+        expect(
+            parseUrlFilters({
+                namespace: 'products',
+                initialFilters,
+                filterKeys: ['id', 'offset', 'limit', 'category', 'sort'],
+                searchParams,
+            }),
+        ).toEqual({
+            id: 'product-list',
+            offset: 0,
+            limit: 12,
+            category: 'coffee',
+            sort: 'name',
+        });
+    });
+});

--- a/packages/ui/src/hooks/use-url-filters.ts
+++ b/packages/ui/src/hooks/use-url-filters.ts
@@ -1,0 +1,306 @@
+'use client';
+
+import * as React from 'react';
+
+type QueryValue = string | number | boolean | null | undefined;
+type QueryValueList = QueryValue[];
+type QueryRecord = Record<string, QueryValue | QueryValueList>;
+
+export type UrlSearchParamsLike = {
+    forEach: (callback: (value: string, key: string) => void) => void;
+    get: (key: string) => string | null;
+    getAll: (key: string) => string[];
+    toString: () => string;
+};
+
+type UrlFilterConfig<TFilters extends object, TViewMode extends string> = {
+    namespace: string;
+    initialFilters: TFilters;
+    filterKeys?: Array<keyof TFilters | string>;
+    initialViewMode: TViewMode;
+    defaultViewMode?: TViewMode;
+    searchParams: UrlSearchParamsLike;
+    pathname: string;
+    onUrlChange: (url: string) => void;
+};
+
+const PAGE_KEY = 'page';
+const VIEW_KEY = 'view';
+
+const scopedKey = (namespace: string, key: string) => `${namespace}_${key}`;
+
+const toSearchParams = (searchParams: UrlSearchParamsLike) => {
+    const params = new URLSearchParams();
+
+    searchParams.forEach((value, key) => {
+        params.append(key, value);
+    });
+
+    return params;
+};
+
+const coerceValue = (value: string, defaultValue: unknown): QueryValue => {
+    if (typeof defaultValue === 'number') {
+        const numericValue = Number(value);
+        return Number.isNaN(numericValue) ? defaultValue : numericValue;
+    }
+
+    if (typeof defaultValue === 'boolean') {
+        return value === 'true';
+    }
+
+    return value;
+};
+
+const normalizeValue = (value: unknown): string | undefined => {
+    if (value === null || value === undefined || value === '') {
+        return undefined;
+    }
+
+    return String(value);
+};
+
+const areEqualValues = (value: unknown, defaultValue: unknown) => {
+    if (Array.isArray(value) || Array.isArray(defaultValue)) {
+        const values = Array.isArray(value) ? value : [value];
+        const defaultValues = Array.isArray(defaultValue) ? defaultValue : [defaultValue];
+
+        return values.map(String).join('\u0000') === defaultValues.map(String).join('\u0000');
+    }
+
+    return String(value ?? '') === String(defaultValue ?? '');
+};
+
+const appendValue = (params: URLSearchParams, key: string, value: unknown) => {
+    if (Array.isArray(value)) {
+        value.forEach((item) => {
+            const normalizedValue = normalizeValue(item);
+
+            if (normalizedValue !== undefined) {
+                params.append(key, normalizedValue);
+            }
+        });
+        return;
+    }
+
+    const normalizedValue = normalizeValue(value);
+
+    if (normalizedValue !== undefined) {
+        params.set(key, normalizedValue);
+    }
+};
+
+export const hasUrlFilterValues = (namespace: string, searchParams: UrlSearchParamsLike) => {
+    const prefix = `${namespace}_`;
+    let hasValues = false;
+
+    searchParams.forEach((_value, key) => {
+        if (key.startsWith(prefix)) {
+            hasValues = true;
+        }
+    });
+
+    return hasValues;
+};
+
+export const parseUrlFilters = <TFilters extends object>({
+    namespace,
+    initialFilters,
+    filterKeys,
+    searchParams,
+}: {
+    namespace: string;
+    initialFilters: TFilters;
+    filterKeys?: Array<keyof TFilters | string>;
+    searchParams: UrlSearchParamsLike;
+}): TFilters => {
+    const nextFilters = { ...initialFilters } as QueryRecord;
+    const initialFilterRecord = initialFilters as QueryRecord;
+    const keys = (filterKeys ?? Object.keys(initialFilterRecord)).map(String);
+    const pageValue = searchParams.get(scopedKey(namespace, PAGE_KEY));
+    const limit = Number(initialFilterRecord.limit ?? 1);
+
+    if (pageValue) {
+        const page = Number(pageValue);
+
+        if (Number.isInteger(page) && page > 0) {
+            nextFilters.offset = (page - 1) * limit;
+        }
+    }
+
+    keys.forEach((key) => {
+        if (key === 'offset') {
+            return;
+        }
+
+        const values = searchParams.getAll(scopedKey(namespace, key));
+
+        if (!values.length) {
+            return;
+        }
+
+        const defaultValue = initialFilterRecord[key];
+
+        if (Array.isArray(defaultValue)) {
+            nextFilters[key] = values.map((value) => coerceValue(value, defaultValue[0]));
+            return;
+        }
+
+        nextFilters[key] = values.length > 1 ? values : coerceValue(values[0], defaultValue);
+    });
+
+    return nextFilters as TFilters;
+};
+
+export const parseUrlViewMode = <TViewMode extends string>({
+    namespace,
+    initialViewMode,
+    searchParams,
+}: {
+    namespace: string;
+    initialViewMode: TViewMode;
+    searchParams: UrlSearchParamsLike;
+}): TViewMode => {
+    return (searchParams.get(scopedKey(namespace, VIEW_KEY)) as TViewMode | null) ?? initialViewMode;
+};
+
+export const serializeUrlFilters = <TFilters extends object, TViewMode extends string>({
+    namespace,
+    initialFilters,
+    filterKeys,
+    filters,
+    viewMode,
+    defaultViewMode,
+    searchParams,
+}: {
+    namespace: string;
+    initialFilters: TFilters;
+    filterKeys?: Array<keyof TFilters | string>;
+    filters: TFilters;
+    viewMode: TViewMode;
+    defaultViewMode: TViewMode;
+    searchParams: UrlSearchParamsLike;
+}) => {
+    const params = toSearchParams(searchParams);
+    const prefix = `${namespace}_`;
+    const filterRecord = filters as QueryRecord;
+    const initialFilterRecord = initialFilters as QueryRecord;
+    const keys = Array.from(
+        new Set([...Object.keys(initialFilterRecord), ...Object.keys(filterRecord), ...(filterKeys ?? []).map(String)]),
+    );
+    const limit = Number(filterRecord.limit ?? initialFilterRecord.limit ?? 1);
+
+    Array.from(params.keys()).forEach((key) => {
+        if (key.startsWith(prefix)) {
+            params.delete(key);
+        }
+    });
+
+    keys.forEach((key) => {
+        const value = filterRecord[key];
+        const defaultValue = initialFilterRecord[key];
+
+        if (key === 'offset') {
+            const offset = Number(value ?? 0);
+            const page = Math.floor(offset / limit) + 1;
+
+            if (page > 1) {
+                params.set(scopedKey(namespace, PAGE_KEY), String(page));
+            }
+
+            return;
+        }
+
+        if (areEqualValues(value, defaultValue)) {
+            return;
+        }
+
+        appendValue(params, scopedKey(namespace, key), value);
+    });
+
+    if (viewMode !== defaultViewMode) {
+        params.set(scopedKey(namespace, VIEW_KEY), viewMode);
+    }
+
+    return params.toString();
+};
+
+export const useUrlFilters = <TFilters extends object, TViewMode extends string>({
+    namespace,
+    initialFilters,
+    filterKeys,
+    initialViewMode,
+    defaultViewMode = 'list' as TViewMode,
+    searchParams,
+    pathname,
+    onUrlChange,
+}: UrlFilterConfig<TFilters, TViewMode>) => {
+    const searchParamsString = searchParams.toString();
+    const filterKeysKey = (filterKeys ?? []).map(String).join('\u0000');
+    const normalizedFilterKeys = React.useMemo(
+        () => (filterKeysKey ? filterKeysKey.split('\u0000') : undefined),
+        [filterKeysKey],
+    );
+
+    const parsedFilters = React.useMemo(
+        () => parseUrlFilters({ namespace, initialFilters, filterKeys: normalizedFilterKeys, searchParams }),
+        [initialFilters, namespace, normalizedFilterKeys, searchParams, searchParamsString],
+    );
+    const parsedViewMode = React.useMemo(
+        () => parseUrlViewMode({ namespace, initialViewMode, searchParams }),
+        [initialViewMode, namespace, searchParams, searchParamsString],
+    );
+
+    const [filters, setFiltersState] = React.useState(parsedFilters);
+    const [viewMode, setViewModeState] = React.useState(parsedViewMode);
+
+    React.useEffect(() => {
+        setFiltersState(parsedFilters);
+    }, [parsedFilters]);
+
+    React.useEffect(() => {
+        setViewModeState(parsedViewMode);
+    }, [parsedViewMode]);
+
+    const updateUrl = React.useCallback(
+        (nextFilters: TFilters, nextViewMode: TViewMode) => {
+            const nextSearchParams = serializeUrlFilters({
+                namespace,
+                initialFilters,
+                filterKeys: normalizedFilterKeys,
+                filters: nextFilters,
+                viewMode: nextViewMode,
+                defaultViewMode,
+                searchParams,
+            });
+            const nextUrl = nextSearchParams ? `${pathname}?${nextSearchParams}` : pathname;
+
+            onUrlChange(nextUrl);
+        },
+        [defaultViewMode, initialFilters, namespace, normalizedFilterKeys, onUrlChange, pathname, searchParams],
+    );
+
+    const setFilters = React.useCallback(
+        (nextFilters: TFilters) => {
+            setFiltersState(nextFilters);
+            updateUrl(nextFilters, viewMode);
+        },
+        [updateUrl, viewMode],
+    );
+
+    const setViewMode = React.useCallback(
+        (nextViewMode: TViewMode) => {
+            setViewModeState(nextViewMode);
+            updateUrl(filters, nextViewMode);
+        },
+        [filters, updateUrl],
+    );
+
+    return {
+        filters,
+        setFilters,
+        viewMode,
+        setViewMode,
+        hasUrlFilters: hasUrlFilterValues(namespace, searchParams),
+    };
+};


### PR DESCRIPTION
**What does this PR do?**

- [x] My bugfix

**Related Ticket(s)**

- Closes #764
- /claim #764

**Key Changes**

- Adds a framework-agnostic `useUrlFilters` hook in `@o2s/ui` for namespaced query param serialization/parsing.
- Supports clean URLs, repeated params for multi-select filters, `{ns}_page` as a 1-based page value, and `{ns}_view` for non-default view modes.
- Migrates `ticket-list`, `order-list`, `invoice-list`, `product-list`, and `notification-list` to use URL-backed filters.
- Preserves unrelated query params and uses `router.replace(..., { scroll: false })` to avoid browser history pollution.
- Adds utility coverage for parsing, serialization, reset cleanup, repeated values, and optional filter keys.
- Adds a changeset for the five public list block packages.

Side effects:

- When a list block loads with matching namespaced URL params, it fetches the filtered data once on mount.
- Query params are namespaced with the component id, falling back to the block name, so multiple blocks can coexist without colliding.

**How to test**

1. Run `npm ci`.
2. Run `npm run lint`.
3. Run `npm run test`.
4. Open pages with list blocks and apply filters/pagination/view mode changes.
5. Confirm the URL updates with namespaced params and that refreshing or opening the URL restores the filtered view.
6. Confirm unrelated query params remain intact when filters change.

Local checks I could run in this environment:

- `git diff --check`
- `prettier@3.8.1 --check` with the repo's main formatting options and `--no-config` because local workspace deps were unavailable
- A `tsx` smoke test importing `parseUrlFilters`, `parseUrlViewMode`, and `serializeUrlFilters` directly

I could not run the full monorepo `npm run lint` / `npm run test` locally because this checkout environment does not have `npm`, `node_modules`, or the internal `@o2s/*` config packages installed.

**Media (Loom or gif)**

- N/A