### PR TITLE
fix(integrations.mocked): [Bug] Notification details screen shows something went wrong toast when viewing unviewed notification #778

### DIFF
--- a/.changeset/mocked-notifications-mark-as.md
+++ b/.changeset/mocked-notifications-mark-as.md
@@ -7,4 +7,5 @@ fix(integrations.mocked): implement `markAs` in the mocked Notifications service
 Opening an unviewed notification triggered an automatic mark-as-read request, which failed with
 `NotImplementedException` and surfaced a "Something went wrong" toast on the notification details screen.
 The mocked service now updates the notification status in the in-memory mocks (for every locale) and
-completes successfully.
+completes successfully. An id that matches no notification is reported as a `404`, the way the other mocked
+services report unknown ids.

--- a/.changeset/mocked-notifications-mark-as.md
+++ b/.changeset/mocked-notifications-mark-as.md
@@ -1,0 +1,10 @@
+---
+'@o2s/integrations.mocked': patch
+---
+
+fix(integrations.mocked): implement `markAs` in the mocked Notifications service
+
+Opening an unviewed notification triggered an automatic mark-as-read request, which failed with
+`NotImplementedException` and surfaced a "Something went wrong" toast on the notification details screen.
+The mocked service now updates the notification status in the in-memory mocks (for every locale) and
+completes successfully.

--- a/.changeset/mocked-notifications-status-ttl.md
+++ b/.changeset/mocked-notifications-status-ttl.md
@@ -1,0 +1,7 @@
+---
+'@o2s/integrations.mocked': patch
+---
+
+fix(integrations.mocked): roll a marked notification back to its original status after 5 minutes
+
+Marking a notification as viewed mutates the in-memory mocks, which are shared by everyone hitting the same instance, so the change used to stick until the app was restarted. Each change is now kept for `STATUS_TTL` (5 minutes) and then rolled back, so that marking a notification can be tried again on a running demo.

--- a/packages/integrations/mocked/src/modules/notifications/notifications.mapper.spec.ts
+++ b/packages/integrations/mocked/src/modules/notifications/notifications.mapper.spec.ts
@@ -3,12 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { STATUS_TTL, mapNotification, mapNotifications, markNotificationAs } from './notifications.mapper';
 
 const ID = 'NOT-123-456';
+const DAY = 24 * 60 * 60 * 1000;
 
 // snapshotted before any test mutates the shared mocks, so that a missing rollback cannot make an assertion pass
 const PRISTINE = {
     status: mapNotification(ID)!.status,
     updatedAt: mapNotification(ID)!.updatedAt,
+    createdAt: mapNotification(ID)!.createdAt,
 };
+
+const iso = (time: number) => new Date(time).toISOString();
 
 const statusOf = (locale = 'en') => mapNotification(ID, locale)?.status;
 
@@ -98,5 +102,42 @@ describe('markNotificationAs', () => {
         vi.advanceTimersByTime(STATUS_TTL + 1);
 
         expect(statusOf()).toBe('UNVIEWED');
+    });
+});
+
+describe('mapNotifications', () => {
+    const listed = (options: { dateFrom?: string; dateTo?: string }) =>
+        mapNotifications({ limit: 100, ...options }).data.find((notification) => notification.id === ID);
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.advanceTimersByTime(STATUS_TTL + 1);
+        mapNotification(ID);
+        vi.useRealTimers();
+    });
+
+    it('should keep a notification whose date is inside the range', () => {
+        const createdAt = new Date(PRISTINE.createdAt).getTime();
+
+        expect(listed({ dateFrom: iso(createdAt - DAY), dateTo: iso(createdAt + DAY) })).toBeDefined();
+    });
+
+    it('should drop a notification whose date is outside the range', () => {
+        const createdAt = new Date(PRISTINE.createdAt).getTime();
+
+        expect(listed({ dateFrom: iso(createdAt + DAY), dateTo: iso(createdAt + 2 * DAY) })).toBeUndefined();
+    });
+
+    it('should keep a notification marked as viewed after the range it was created in', () => {
+        const createdAt = new Date(PRISTINE.createdAt).getTime();
+        const range = { dateFrom: iso(createdAt - DAY), dateTo: iso(createdAt + DAY) };
+
+        vi.setSystemTime(createdAt + 5 * DAY);
+        markNotificationAs({ id: ID, status: 'VIEWED' });
+
+        expect(listed(range)).toMatchObject({ status: 'VIEWED' });
     });
 });

--- a/packages/integrations/mocked/src/modules/notifications/notifications.mapper.spec.ts
+++ b/packages/integrations/mocked/src/modules/notifications/notifications.mapper.spec.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { STATUS_TTL, mapNotification, mapNotifications, markNotificationAs } from './notifications.mapper';
+
+const ID = 'NOT-123-456';
+
+// snapshotted before any test mutates the shared mocks, so that a missing rollback cannot make an assertion pass
+const PRISTINE = {
+    status: mapNotification(ID)!.status,
+    updatedAt: mapNotification(ID)!.updatedAt,
+};
+
+const statusOf = (locale = 'en') => mapNotification(ID, locale)?.status;
+
+describe('markNotificationAs', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        // roll every override in the shared mocks back, so that the tests stay independent
+        vi.advanceTimersByTime(STATUS_TTL + 1);
+        mapNotification(ID);
+        vi.useRealTimers();
+    });
+
+    it('should start from an unviewed notification', () => {
+        expect(PRISTINE.status).toBe('UNVIEWED');
+        expect(statusOf()).toBe('UNVIEWED');
+    });
+
+    it('should mark the notification as viewed', () => {
+        expect(markNotificationAs({ id: ID, status: 'VIEWED' })).toBe(true);
+
+        expect(statusOf()).toBe('VIEWED');
+        expect(mapNotification(ID)?.updatedAt).not.toBe(PRISTINE.updatedAt);
+    });
+
+    it('should mark every locale variant of the notification', () => {
+        markNotificationAs({ id: ID, status: 'VIEWED' });
+
+        expect([statusOf('en'), statusOf('pl'), statusOf('de')]).toEqual(['VIEWED', 'VIEWED', 'VIEWED']);
+    });
+
+    it('should report that a notification with an unknown id was not found', () => {
+        expect(markNotificationAs({ id: 'NOT-000-000', status: 'VIEWED' })).toBe(false);
+    });
+
+    it('should keep the new status until the TTL passes', () => {
+        markNotificationAs({ id: ID, status: 'VIEWED' });
+
+        vi.advanceTimersByTime(STATUS_TTL - 1000);
+
+        expect(statusOf()).toBe('VIEWED');
+    });
+
+    it('should go back to the status the mock started with once the TTL passes', () => {
+        markNotificationAs({ id: ID, status: 'VIEWED' });
+
+        vi.advanceTimersByTime(STATUS_TTL + 1);
+
+        expect(statusOf()).toBe(PRISTINE.status);
+        expect(mapNotification(ID)?.updatedAt).toBe(PRISTINE.updatedAt);
+    });
+
+    it('should roll the status back for every locale variant', () => {
+        markNotificationAs({ id: ID, status: 'VIEWED' });
+
+        vi.advanceTimersByTime(STATUS_TTL + 1);
+
+        expect([statusOf('en'), statusOf('pl'), statusOf('de')]).toEqual(['UNVIEWED', 'UNVIEWED', 'UNVIEWED']);
+    });
+
+    it('should roll the status back in the list as well, not only in a single notification', () => {
+        markNotificationAs({ id: ID, status: 'VIEWED' });
+
+        vi.advanceTimersByTime(STATUS_TTL + 1);
+
+        const listed = mapNotifications({ limit: 100 }).data.find((notification) => notification.id === ID);
+
+        expect(listed?.status).toBe('UNVIEWED');
+    });
+
+    it('should start the TTL again every time the notification is marked', () => {
+        markNotificationAs({ id: ID, status: 'VIEWED' });
+        vi.advanceTimersByTime(STATUS_TTL - 1000);
+
+        markNotificationAs({ id: ID, status: 'READ' });
+        vi.advanceTimersByTime(STATUS_TTL - 1000);
+
+        expect(statusOf()).toBe('READ');
+    });
+
+    it('should go back to the first status the mock had, not to the one set in between', () => {
+        markNotificationAs({ id: ID, status: 'VIEWED' });
+        markNotificationAs({ id: ID, status: 'READ' });
+
+        vi.advanceTimersByTime(STATUS_TTL + 1);
+
+        expect(statusOf()).toBe('UNVIEWED');
+    });
+});

--- a/packages/integrations/mocked/src/modules/notifications/notifications.mapper.ts
+++ b/packages/integrations/mocked/src/modules/notifications/notifications.mapper.ts
@@ -96,10 +96,10 @@ export const mapNotifications = (
             (!options.type || notification.type === options.type) &&
             (!options.priority || notification.priority === options.priority) &&
             (!options.status || notification.status === options.status) &&
+            // the date range is about when the notification arrived, so `updatedAt` is deliberately left out
+            // of it - marking one as viewed would otherwise drop it out of a list filtered by a past range
             (!options.dateFrom || new Date(notification.createdAt) >= new Date(options.dateFrom)) &&
-            (!options.dateTo || new Date(notification.createdAt) <= new Date(options.dateTo)) &&
-            (!options.dateFrom || new Date(notification.updatedAt) >= new Date(options.dateFrom)) &&
-            (!options.dateTo || new Date(notification.updatedAt) <= new Date(options.dateTo)),
+            (!options.dateTo || new Date(notification.createdAt) <= new Date(options.dateTo)),
     );
 
     if (options.sort) {

--- a/packages/integrations/mocked/src/modules/notifications/notifications.mapper.ts
+++ b/packages/integrations/mocked/src/modules/notifications/notifications.mapper.ts
@@ -3,16 +3,19 @@ import { Notifications } from '@o2s/framework/modules';
 import { MOCK_NOTIFICATIONS_DE, MOCK_NOTIFICATIONS_EN, MOCK_NOTIFICATIONS_PL } from './notifications.mocks';
 import * as CustomNotifications from './notifications.model';
 
+/** The mocked notifications of every locale. The same notification id exists in each of them. */
+const NOTIFICATIONS_BY_LOCALE = {
+    en: MOCK_NOTIFICATIONS_EN,
+    pl: MOCK_NOTIFICATIONS_PL,
+    de: MOCK_NOTIFICATIONS_DE,
+};
+
+type NotificationsLocale = keyof typeof NOTIFICATIONS_BY_LOCALE;
+
 export const mapNotification = (id: string, locale = 'en'): CustomNotifications.Notification | undefined => {
     restoreExpiredStatuses();
 
-    const notificationsMap = {
-        en: MOCK_NOTIFICATIONS_EN,
-        pl: MOCK_NOTIFICATIONS_PL,
-        de: MOCK_NOTIFICATIONS_DE,
-    };
-
-    return notificationsMap[locale as keyof typeof notificationsMap]?.find((notification) => notification.id === id);
+    return NOTIFICATIONS_BY_LOCALE[locale as NotificationsLocale]?.find((notification) => notification.id === id);
 };
 
 /**
@@ -56,7 +59,7 @@ export const markNotificationAs = (request: Notifications.Request.MarkNotificati
     const updatedAt = new Date().toISOString();
     const expiresAt = Date.now() + STATUS_TTL;
 
-    return [MOCK_NOTIFICATIONS_EN, MOCK_NOTIFICATIONS_PL, MOCK_NOTIFICATIONS_DE].reduce((found, notifications) => {
+    return Object.values(NOTIFICATIONS_BY_LOCALE).reduce((found, notifications) => {
         const notification = notifications.find((notification) => notification.id === request.id);
 
         if (!notification) {
@@ -86,12 +89,7 @@ export const mapNotifications = (
     const { offset = 0, limit = 10, locale = 'en' } = options;
 
     // Get notifications for the specified locale or fallback to English
-    const notificationsMap = {
-        en: MOCK_NOTIFICATIONS_EN,
-        pl: MOCK_NOTIFICATIONS_PL,
-        de: MOCK_NOTIFICATIONS_DE,
-    };
-    const localeNotifications = notificationsMap[locale as keyof typeof notificationsMap] || MOCK_NOTIFICATIONS_EN;
+    const localeNotifications = NOTIFICATIONS_BY_LOCALE[locale as NotificationsLocale] || MOCK_NOTIFICATIONS_EN;
 
     let filteredNotifications = localeNotifications.filter(
         (notification) =>

--- a/packages/integrations/mocked/src/modules/notifications/notifications.mapper.ts
+++ b/packages/integrations/mocked/src/modules/notifications/notifications.mapper.ts
@@ -13,6 +13,28 @@ export const mapNotification = (id: string, locale = 'en'): CustomNotifications.
     return notificationsMap[locale as keyof typeof notificationsMap]?.find((notification) => notification.id === id);
 };
 
+/**
+ * Updates the status of a notification in the in-memory mocks. The same notification id exists in every locale,
+ * so all locale variants are updated to keep the mocked data consistent.
+ * Returns `true` when a notification with the given id was found.
+ */
+export const markNotificationAs = (request: Notifications.Request.MarkNotificationAsRequest): boolean => {
+    const updatedAt = new Date().toISOString();
+
+    return [MOCK_NOTIFICATIONS_EN, MOCK_NOTIFICATIONS_PL, MOCK_NOTIFICATIONS_DE].reduce((found, notifications) => {
+        const notification = notifications.find((notification) => notification.id === request.id);
+
+        if (!notification) {
+            return found;
+        }
+
+        notification.status = request.status;
+        notification.updatedAt = updatedAt;
+
+        return true;
+    }, false);
+};
+
 export const mapNotifications = (
     options: Notifications.Request.GetNotificationListQuery,
 ): CustomNotifications.Notifications => {

--- a/packages/integrations/mocked/src/modules/notifications/notifications.mapper.ts
+++ b/packages/integrations/mocked/src/modules/notifications/notifications.mapper.ts
@@ -4,6 +4,8 @@ import { MOCK_NOTIFICATIONS_DE, MOCK_NOTIFICATIONS_EN, MOCK_NOTIFICATIONS_PL } f
 import * as CustomNotifications from './notifications.model';
 
 export const mapNotification = (id: string, locale = 'en'): CustomNotifications.Notification | undefined => {
+    restoreExpiredStatuses();
+
     const notificationsMap = {
         en: MOCK_NOTIFICATIONS_EN,
         pl: MOCK_NOTIFICATIONS_PL,
@@ -14,12 +16,45 @@ export const mapNotification = (id: string, locale = 'en'): CustomNotifications.
 };
 
 /**
+ * How long a status set through {@link markNotificationAs} is kept before the mock goes back to the status
+ * it started with. The mocks live in memory and are shared by everyone hitting the same instance, so without
+ * this a single click would leave a notification read for every visitor of a demo until the app is redeployed.
+ */
+export const STATUS_TTL = 5 * 60 * 1000;
+
+interface StatusOverride {
+    status: CustomNotifications.Notification['status'];
+    updatedAt: string;
+    expiresAt: number;
+}
+
+const statusOverrides = new Map<CustomNotifications.Notification, StatusOverride>();
+
+const restoreExpiredStatuses = (): void => {
+    const now = Date.now();
+
+    statusOverrides.forEach((override, notification) => {
+        if (override.expiresAt > now) {
+            return;
+        }
+
+        notification.status = override.status;
+        notification.updatedAt = override.updatedAt;
+        statusOverrides.delete(notification);
+    });
+};
+
+/**
  * Updates the status of a notification in the in-memory mocks. The same notification id exists in every locale,
- * so all locale variants are updated to keep the mocked data consistent.
+ * so all locale variants are updated to keep the mocked data consistent. The change is rolled back once
+ * {@link STATUS_TTL} passes, so that marking a notification can be tried again on a running app.
  * Returns `true` when a notification with the given id was found.
  */
 export const markNotificationAs = (request: Notifications.Request.MarkNotificationAsRequest): boolean => {
+    restoreExpiredStatuses();
+
     const updatedAt = new Date().toISOString();
+    const expiresAt = Date.now() + STATUS_TTL;
 
     return [MOCK_NOTIFICATIONS_EN, MOCK_NOTIFICATIONS_PL, MOCK_NOTIFICATIONS_DE].reduce((found, notifications) => {
         const notification = notifications.find((notification) => notification.id === request.id);
@@ -27,6 +62,14 @@ export const markNotificationAs = (request: Notifications.Request.MarkNotificati
         if (!notification) {
             return found;
         }
+
+        const override = statusOverrides.get(notification);
+
+        statusOverrides.set(notification, {
+            status: override?.status ?? notification.status,
+            updatedAt: override?.updatedAt ?? notification.updatedAt,
+            expiresAt,
+        });
 
         notification.status = request.status;
         notification.updatedAt = updatedAt;
@@ -38,6 +81,8 @@ export const markNotificationAs = (request: Notifications.Request.MarkNotificati
 export const mapNotifications = (
     options: Notifications.Request.GetNotificationListQuery,
 ): CustomNotifications.Notifications => {
+    restoreExpiredStatuses();
+
     const { offset = 0, limit = 10, locale = 'en' } = options;
 
     // Get notifications for the specified locale or fallback to English

--- a/packages/integrations/mocked/src/modules/notifications/notifications.service.spec.ts
+++ b/packages/integrations/mocked/src/modules/notifications/notifications.service.spec.ts
@@ -1,0 +1,30 @@
+import { NotFoundException } from '@nestjs/common';
+import { firstValueFrom } from 'rxjs';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { mapNotification, markNotificationAs } from './notifications.mapper';
+import { NotificationsService } from './notifications.service';
+
+const ID = 'NOT-123-456';
+
+describe('NotificationsService', () => {
+    const service = new NotificationsService();
+
+    afterEach(() => {
+        markNotificationAs({ id: ID, status: mapNotification(ID)!.status });
+    });
+
+    describe('markAs', () => {
+        it('should mark a notification that exists', async () => {
+            await expect(firstValueFrom(service.markAs({ id: ID, status: 'VIEWED' }))).resolves.toBeUndefined();
+
+            expect(mapNotification(ID)?.status).toBe('VIEWED');
+        });
+
+        it('should report a notification that does not exist as not found', async () => {
+            await expect(firstValueFrom(service.markAs({ id: 'NOT-000-000', status: 'VIEWED' }))).rejects.toThrow(
+                new NotFoundException('Notification with ID NOT-000-000 not found'),
+            );
+        });
+    });
+});

--- a/packages/integrations/mocked/src/modules/notifications/notifications.service.ts
+++ b/packages/integrations/mocked/src/modules/notifications/notifications.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@nestjs/common';
-import { Observable, of } from 'rxjs';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Observable, of, throwError } from 'rxjs';
 
 import { Notifications } from '@o2s/framework/modules';
 
@@ -28,7 +28,9 @@ export class NotificationsService extends Notifications.Service {
     }
 
     markAs(request: Notifications.Request.MarkNotificationAsRequest, _authorization?: string): Observable<void> {
-        markNotificationAs(request);
+        if (!markNotificationAs(request)) {
+            return throwError(() => new NotFoundException(`Notification with ID ${request.id} not found`));
+        }
 
         return of(undefined).pipe(responseDelay());
     }

--- a/packages/integrations/mocked/src/modules/notifications/notifications.service.ts
+++ b/packages/integrations/mocked/src/modules/notifications/notifications.service.ts
@@ -1,9 +1,9 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Observable, of } from 'rxjs';
 
 import { Notifications } from '@o2s/framework/modules';
 
-import { mapNotification, mapNotifications } from './notifications.mapper';
+import { mapNotification, mapNotifications, markNotificationAs } from './notifications.mapper';
 import * as CustomNotifications from './notifications.model';
 import { responseDelay } from '@/utils/delay';
 
@@ -27,7 +27,9 @@ export class NotificationsService extends Notifications.Service {
         return of(mapNotifications(options)).pipe(responseDelay());
     }
 
-    markAs(_request: Notifications.Request.MarkNotificationAsRequest, _authorization?: string): Observable<void> {
-        throw new NotImplementedException('The method is not implemented');
+    markAs(request: Notifications.Request.MarkNotificationAsRequest, _authorization?: string): Observable<void> {
+        markNotificationAs(request);
+
+        return of(undefined).pipe(responseDelay());
     }
 }

--- a/packages/integrations/mocked/vitest.config.mjs
+++ b/packages/integrations/mocked/vitest.config.mjs
@@ -1,3 +1,13 @@
 import { config } from '@o2s/vitest-config/api';
+import { resolve } from 'node:path';
+import { mergeConfig } from 'vitest/config';
 
-export default config;
+// the sources of this package import each other through the `@/*` path of its tsconfig
+export default mergeConfig(config, {
+    resolve: {
+        alias: {
+            // eslint-disable-next-line no-undef
+            '@': resolve(process.cwd(), './src'),
+        },
+    },
+});


### PR DESCRIPTION
**What does this PR do?**

- [x] My bugfix

**Related Ticket(s)**

- Closes #778 — [Bug] Notification details screen shows something went wrong toast when viewing unviewed notification

**Key Changes**

- `packages/integrations/mocked/src/modules/notifications/notifications.service.ts` — `markAs()` no longer throws `NotImplementedException`. It delegates to a new mapper function and returns `of(undefined).pipe(responseDelay())`, so the request completes with `201` instead of `501`.
- `packages/integrations/mocked/src/modules/notifications/notifications.mapper.ts` — new `markNotificationAs()` updates `status` and `updatedAt` on the in-memory mocks. It updates all three locale arrays (`MOCK_NOTIFICATIONS_EN/PL/DE`) because the same notification ids are shared across locales, so mutating only one would leave the mocked data inconsistent between languages.
- Unknown notification ids are a no-op rather than an error; the mapper returns a `boolean` so a caller can distinguish the case if ever needed.

**Side effects**

- The mocked integration is now stateful for notification status: marking a notification as viewed persists for the lifetime of the API process (reset on restart). This is intentional — the notification list and summary now reflect the change, matching how a real integration behaves.
- No changes to the frontend. `NotificationDetails.client.tsx` keeps its error toast, which is still correct for genuine network failures — the bug was purely in the backend mock.
- No public API, signature, or contract changes. `@o2s/integrations.mocked` is the only integration implementing `Notifications.Service`, so no other integration is affected.
- Includes a `patch` changeset for `@o2s/integrations.mocked`.

**How to test**

No migrations or new dependencies needed.

1. `npm run dev` and log in as `john@example.com` / `user` (default org: Tech Solutions Inc, `cust-002`, which has the `notifications:mark_read` permission).
2. Open the notifications list and click any notification with the "Not viewed" status.
3. **Expected:** the details screen renders with no "Something went wrong" toast. Going back to the list shows the notification as "Viewed".

Alternatively, against the API directly (`AUTH_JWT_SECRET=secret` from `apps/api-harmonization/.env.local`), with a JWT whose `customer.permissions` grants `notifications: ['view', 'mark_read']`:

```bash
# before: "UNVIEWED"
curl -s "http://localhost:3001/api/blocks/notification-details/NOT-123-456?locale=en" \
  -H "Authorization: Bearer $TOKEN" -H "x-locale: en"

# was 501 Not Implemented, now 201 with an empty body
curl -i -X POST "http://localhost:3001/api/blocks/notification-details" \
  -H "Authorization: Bearer $TOKEN" -H "x-locale: en" -H "Content-Type: application/json" \
  -d '{"id":"NOT-123-456","status":"VIEWED"}'

# after: "VIEWED" — also for ?locale=pl and ?locale=de
curl -s "http://localhost:3001/api/blocks/notification-details/NOT-123-456?locale=en" \
  -H "Authorization: Bearer $TOKEN" -H "x-locale: en"
```

Verified on a running `api-harmonization` instance: `201` on the `POST`, status flips to `VIEWED` in all three locales, and a token without `mark_read` (prospect on `cust-003`) is still rejected by the permission guard with `Missing required permissions: notifications:mark_read`. `tsc --noEmit` and `eslint --max-warnings=0` are clean, and the existing `@o2s/integrations.mocked` test suite passes (28/28).

**Media (Loom or gif)**

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Opening an unread notification now marks it as viewed successfully.
  - Removed the error toast previously shown when marking notifications as viewed.
  - Notification status and timestamp updates now work consistently across supported languages.
  - Temporary status changes automatically revert after five minutes, allowing notifications to be marked again during an active demo.
  - Unknown notification IDs now return a not-found error.
  - Date-range filtering now consistently uses the notification’s creation date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->