### PR TITLE
feat(framework): create helper for block SDK method pattern (#770)

### DIFF
--- a/.changeset/create-block-method-helper.md
+++ b/.changeset/create-block-method-helper.md
@@ -1,0 +1,53 @@
+---
+'@o2s/framework': minor
+'@o2s/utils.frontend': patch
+'@o2s/modules.surveyjs': patch
+'@o2s/blocks.article': patch
+'@o2s/blocks.article-list': patch
+'@o2s/blocks.article-search': patch
+'@o2s/blocks.bento-grid': patch
+'@o2s/blocks.cart': patch
+'@o2s/blocks.category': patch
+'@o2s/blocks.category-list': patch
+'@o2s/blocks.checkout-billing-payment': patch
+'@o2s/blocks.checkout-company-data': patch
+'@o2s/blocks.checkout-shipping-address': patch
+'@o2s/blocks.checkout-summary': patch
+'@o2s/blocks.cta-section': patch
+'@o2s/blocks.document-list': patch
+'@o2s/blocks.faq': patch
+'@o2s/blocks.feature-section': patch
+'@o2s/blocks.feature-section-grid': patch
+'@o2s/blocks.featured-service-list': patch
+'@o2s/blocks.hero-section': patch
+'@o2s/blocks.invoice-list': patch
+'@o2s/blocks.media-section': patch
+'@o2s/blocks.notification-details': patch
+'@o2s/blocks.notification-list': patch
+'@o2s/blocks.notification-summary': patch
+'@o2s/blocks.order-confirmation': patch
+'@o2s/blocks.order-details': patch
+'@o2s/blocks.order-list': patch
+'@o2s/blocks.orders-summary': patch
+'@o2s/blocks.payments-history': patch
+'@o2s/blocks.payments-summary': patch
+'@o2s/blocks.pricing-section': patch
+'@o2s/blocks.product-details': patch
+'@o2s/blocks.product-list': patch
+'@o2s/blocks.quick-links': patch
+'@o2s/blocks.recommended-products': patch
+'@o2s/blocks.service-details': patch
+'@o2s/blocks.service-list': patch
+'@o2s/blocks.surveyjs-form': patch
+'@o2s/blocks.ticket-details': patch
+'@o2s/blocks.ticket-list': patch
+'@o2s/blocks.ticket-recent': patch
+'@o2s/blocks.ticket-summary': patch
+'@o2s/blocks.user-account': patch
+---
+
+feat(framework): add `createBlockMethod` helper for block SDK methods
+
+Adds `createBlockMethod` to `@o2s/framework/sdk`. It creates the request function used by the methods of a block (or module) SDK and takes care of the boilerplate that was previously copy-pasted into every method: merging the default API headers with the caller's headers and the access token, serializing query params, typing the response and wrapping failures into a `BlockRequestError` (which exposes `status`, `data` and the original error as `cause`).
+
+`getApiHeaders` is now provided by `@o2s/framework/headers` and re-exported by `@o2s/utils.frontend` (`Utils.Headers.getApiHeaders`), so the default headers are defined in a single place. All block SDKs, the SurveyJS module SDK and the block generator template use the new helper.

--- a/.changeset/create-block-request-helper.md
+++ b/.changeset/create-block-request-helper.md
@@ -46,8 +46,8 @@
 '@o2s/blocks.user-account': patch
 ---
 
-feat(framework): add `createBlockMethod` helper for block SDK methods
+feat(framework): add `createBlockRequest` helper for block SDK methods
 
-Adds `createBlockMethod` to `@o2s/framework/sdk`. It creates the request function used by the methods of a block (or module) SDK and takes care of the boilerplate that was previously copy-pasted into every method: merging the default API headers with the caller's headers and the access token, serializing query params, typing the response and wrapping failures into a `BlockRequestError` (which exposes `status`, `data` and the original error as `cause`).
+Adds `createBlockRequest` to `@o2s/framework/sdk`. It creates the request function used by the methods of a block (or module) SDK and takes care of the boilerplate that was previously copy-pasted into every method: merging the default API headers with the caller's headers and the access token, serializing query params, typing the response and wrapping failures into a `BlockRequestError` (which exposes `status`, `data` and the original error as `cause`).
 
 `getApiHeaders` is now provided by `@o2s/framework/headers` and re-exported by `@o2s/utils.frontend` (`Utils.Headers.getApiHeaders`), so the default headers are defined in a single place. All block SDKs, the SurveyJS module SDK and the block generator template use the new helper.

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -73,6 +73,7 @@ const config: StorybookConfig = {
             },
             optimizeDeps: {
                 include: [
+                    '@o2s/framework/headers',
                     '@o2s/framework/modules',
                     '@o2s/framework/sdk',
                     'storybook/test',
@@ -91,6 +92,7 @@ const config: StorybookConfig = {
                     '@o2s/configs.integrations/live-preview': path.resolve(__dirname, './mocks/live-preview.mock.ts'),
                     '@o2s/framework/sdk': path.resolve(__dirname, '../packages/framework/src/sdk.ts'),
                     '@o2s/framework/modules': path.resolve(__dirname, '../packages/framework/src/index.ts'),
+                    '@o2s/framework/headers': path.resolve(__dirname, '../packages/framework/src/headers.ts'),
                     '@o2s/ui': path.resolve(__dirname, '../packages/ui/src'),
                     '@o2s/ui/components': path.resolve(__dirname, '../packages/ui/src/components'),
                     '@o2s/utils.api-harmonization': path.resolve(__dirname, './mocks/utils.api-harmonization.mock.ts'),

--- a/apps/docs/docs/main-components/blocks/structure.md
+++ b/apps/docs/docs/main-components/blocks/structure.md
@@ -181,3 +181,40 @@ The SDK part is a thin slice of the the [general SDK used globally](../../guides
 
 - internally with the block (including server and client compoennts),
 - externally by other frontend apps in cases when you'd like to completely take over the rendering, and re-use only the normalized and aggregated data.
+
+Each method of that SDK is built with the `createBlockMethod` helper, which handles the parts that are the same for every block: merging the default API headers with the ones passed by the caller and with the access token, serializing the query params, typing the response and wrapping errors:
+
+```typescript
+import { AppHeaders } from '@o2s/framework/headers';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+
+import { Model, Request, URL } from '../api-harmonization/faq.client';
+
+export const faq = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getFaq: (
+                query: Request.GetFaqBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.FaqBlock> =>
+                request({
+                    url: URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};
+```
+
+Apart from `url`, `params`, `headers` and `authorization`, the request accepts:
+
+- `method` - HTTP method of the request, `get` by default,
+- `data` - the request body,
+- `responseType` - the expected response type, `json` by default.
+
+Whenever a request fails, a `BlockRequestError` is thrown. Besides the message (which contains the method and the URL of the failed request), it exposes the `status` and `data` returned by the server, while the original error remains available as `cause`.

--- a/apps/docs/docs/main-components/blocks/structure.md
+++ b/apps/docs/docs/main-components/blocks/structure.md
@@ -182,16 +182,16 @@ The SDK part is a thin slice of the the [general SDK used globally](../../guides
 - internally with the block (including server and client compoennts),
 - externally by other frontend apps in cases when you'd like to completely take over the rendering, and re-use only the normalized and aggregated data.
 
-Each method of that SDK is built with the `createBlockMethod` helper, which handles the parts that are the same for every block: merging the default API headers with the ones passed by the caller and with the access token, serializing the query params, typing the response and wrapping errors:
+Each method of that SDK is built with the `createBlockRequest` helper, which handles the parts that are the same for every block: merging the default API headers with the ones passed by the caller and with the access token, serializing the query params, typing the response and wrapping errors:
 
 ```typescript
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/faq.client';
 
 export const faq = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/apps/frontend/src/api/modules/cart.ts
+++ b/apps/frontend/src/api/modules/cart.ts
@@ -1,11 +1,11 @@
 import { AppHeaders } from '@o2s/framework/headers';
 import { Carts } from '@o2s/framework/modules';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 const CARTS_API_URL = '/carts';
 
 export const cart = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         cart: {

--- a/apps/frontend/src/api/modules/cart.ts
+++ b/apps/frontend/src/api/modules/cart.ts
@@ -1,33 +1,27 @@
 import { AppHeaders } from '@o2s/framework/headers';
 import { Carts } from '@o2s/framework/modules';
-import { Sdk } from '@o2s/framework/sdk';
-
-import { getApiHeaders } from '../../utils/api';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 const CARTS_API_URL = '/carts';
 
-export const cart = (sdk: Sdk) => ({
-    cart: {
-        getCurrentCart: (headers: AppHeaders, authorization?: string): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${CARTS_API_URL}/current`,
-                headers: {
-                    ...getApiHeaders(),
-                    ...headers,
-                    ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
-                },
-            }),
+export const cart = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
 
-        getCart: (cartId: string, headers: AppHeaders, authorization?: string): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${CARTS_API_URL}/${cartId}`,
-                headers: {
-                    ...getApiHeaders(),
-                    ...headers,
-                    ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
-                },
-            }),
-    },
-});
+    return {
+        cart: {
+            getCurrentCart: (headers: AppHeaders, authorization?: string): Promise<Carts.Model.Cart> =>
+                request({
+                    url: `${CARTS_API_URL}/current`,
+                    headers,
+                    authorization,
+                }),
+
+            getCart: (cartId: string, headers: AppHeaders, authorization?: string): Promise<Carts.Model.Cart> =>
+                request({
+                    url: `${CARTS_API_URL}/${cartId}`,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/apps/frontend/src/api/modules/cart.ts
+++ b/apps/frontend/src/api/modules/cart.ts
@@ -18,7 +18,7 @@ export const cart = (sdk: Sdk) => {
 
             getCart: (cartId: string, headers: AppHeaders, authorization?: string): Promise<Carts.Model.Cart> =>
                 request({
-                    url: `${CARTS_API_URL}/${cartId}`,
+                    url: `${CARTS_API_URL}/${encodeURIComponent(cartId)}`,
                     headers,
                     authorization,
                 }),

--- a/apps/frontend/src/api/modules/login-page.ts
+++ b/apps/frontend/src/api/modules/login-page.ts
@@ -2,12 +2,12 @@ import { Modules } from '@o2s/api-harmonization';
 import { URL } from '@o2s/api-harmonization/modules/login-page/login-page.url';
 
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 const API_URL = URL;
 
 export const loginPage = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         modules: {

--- a/apps/frontend/src/api/modules/login-page.ts
+++ b/apps/frontend/src/api/modules/login-page.ts
@@ -2,22 +2,20 @@ import { Modules } from '@o2s/api-harmonization';
 import { URL } from '@o2s/api-harmonization/modules/login-page/login-page.url';
 
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
-
-import { getApiHeaders } from '../../utils/api';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 const API_URL = URL;
 
-export const loginPage = (sdk: Sdk) => ({
-    modules: {
-        getLoginPage: (headers: AppHeaders): Promise<Modules.LoginPage.Model.LoginPage> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...getApiHeaders(),
-                    ...headers,
-                },
-            }),
-    },
-});
+export const loginPage = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        modules: {
+            getLoginPage: (headers: AppHeaders): Promise<Modules.LoginPage.Model.LoginPage> =>
+                request({
+                    url: API_URL,
+                    headers,
+                }),
+        },
+    };
+};

--- a/apps/frontend/src/api/modules/not-found-page.ts
+++ b/apps/frontend/src/api/modules/not-found-page.ts
@@ -2,12 +2,12 @@ import { Modules } from '@o2s/api-harmonization';
 import { URL } from '@o2s/api-harmonization/modules/not-found-page/not-found-page.url';
 
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 const API_URL = URL;
 
 export const notFoundPage = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         modules: {

--- a/apps/frontend/src/api/modules/not-found-page.ts
+++ b/apps/frontend/src/api/modules/not-found-page.ts
@@ -2,31 +2,25 @@ import { Modules } from '@o2s/api-harmonization';
 import { URL } from '@o2s/api-harmonization/modules/not-found-page/not-found-page.url';
 
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
-
-import { getApiHeaders } from '../../utils/api';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 const API_URL = URL;
 
-export const notFoundPage = (sdk: Sdk) => ({
-    modules: {
-        getNotFoundPage: (
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Modules.NotFoundPage.Model.NotFoundPage> => {
-            return sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-            });
+export const notFoundPage = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        modules: {
+            getNotFoundPage: (
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Modules.NotFoundPage.Model.NotFoundPage> => {
+                return request({
+                    url: API_URL,
+                    headers,
+                    authorization,
+                });
+            },
         },
-    },
-});
+    };
+};

--- a/apps/frontend/src/api/modules/organizations.ts
+++ b/apps/frontend/src/api/modules/organizations.ts
@@ -2,32 +2,26 @@ import { Modules } from '@o2s/api-harmonization';
 import { URL } from '@o2s/api-harmonization/modules/organizations/organizations.url';
 
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
-
-import { getApiHeaders } from '../../utils/api';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 const API_URL = URL;
 
-export const organizations = (sdk: Sdk) => ({
-    modules: {
-        getCustomers: (
-            query: Modules.Organizations.Request.GetCustomersQuery,
-            headers: AppHeaders,
-            authorization: string,
-        ): Promise<Modules.Organizations.Model.CustomerList> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const organizations = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        modules: {
+            getCustomers: (
+                query: Modules.Organizations.Request.GetCustomersQuery,
+                headers: AppHeaders,
+                authorization: string,
+            ): Promise<Modules.Organizations.Model.CustomerList> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/apps/frontend/src/api/modules/organizations.ts
+++ b/apps/frontend/src/api/modules/organizations.ts
@@ -2,12 +2,12 @@ import { Modules } from '@o2s/api-harmonization';
 import { URL } from '@o2s/api-harmonization/modules/organizations/organizations.url';
 
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 const API_URL = URL;
 
 export const organizations = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         modules: {

--- a/apps/frontend/src/api/modules/page.ts
+++ b/apps/frontend/src/api/modules/page.ts
@@ -2,51 +2,37 @@ import { Modules } from '@o2s/api-harmonization';
 import { URL } from '@o2s/api-harmonization/modules/page/page.url';
 
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
-
-import { getApiHeaders } from '../../utils/api';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 const API_URL = URL;
 
-export const page = (sdk: Sdk) => ({
-    modules: {
-        getInit: (
-            params: Modules.Page.Request.GetInitQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Modules.Page.Model.Init> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}/init`,
-                headers: {
-                    ...getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: params,
-            }),
-        getPage: (
-            params: Modules.Page.Request.GetPageQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Modules.Page.Model.Page> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: params,
-            }),
-    },
-});
+export const page = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        modules: {
+            getInit: (
+                params: Modules.Page.Request.GetInitQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Modules.Page.Model.Init> =>
+                request({
+                    url: `${API_URL}/init`,
+                    params: params,
+                    headers,
+                    authorization,
+                }),
+            getPage: (
+                params: Modules.Page.Request.GetPageQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Modules.Page.Model.Page> =>
+                request({
+                    url: API_URL,
+                    params: params,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/apps/frontend/src/api/modules/page.ts
+++ b/apps/frontend/src/api/modules/page.ts
@@ -2,12 +2,12 @@ import { Modules } from '@o2s/api-harmonization';
 import { URL } from '@o2s/api-harmonization/modules/page/page.url';
 
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 const API_URL = URL;
 
 export const page = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         modules: {

--- a/apps/frontend/src/utils/api.ts
+++ b/apps/frontend/src/utils/api.ts
@@ -1,5 +1,0 @@
-export const getApiHeaders = () => {
-    return {
-        'x-client-timezone': Intl.DateTimeFormat().resolvedOptions().timeZone,
-    };
-};

--- a/packages/blocks/account/user-account/src/sdk/user-account.ts
+++ b/packages/blocks/account/user-account/src/sdk/user-account.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/user-account.client';
 import { URL } from '../api-harmonization/user-account.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/user-account.url';
 const API_URL = URL;
 
 export const userAccount = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/account/user-account/src/sdk/user-account.ts
+++ b/packages/blocks/account/user-account/src/sdk/user-account.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/user-account.client';
 import { URL } from '../api-harmonization/user-account.url';
 
 const API_URL = URL;
 
-export const userAccount = (sdk: Sdk) => ({
-    blocks: {
-        getUserAccount: (
-            query: Request.GetUserAccountBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.UserAccountBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const userAccount = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getUserAccount: (
+                query: Request.GetUserAccountBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.UserAccountBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/billing/invoice-list/src/sdk/invoice-list.ts
+++ b/packages/blocks/billing/invoice-list/src/sdk/invoice-list.ts
@@ -1,48 +1,34 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/invoice-list.client';
 import { URL } from '../api-harmonization/invoice-list.url';
 
 const API_URL = URL;
 
-export const invoiceList = (sdk: Sdk) => ({
-    blocks: {
-        getInvoiceList: (
-            query: Request.GetInvoiceListBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.InvoiceListBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-        getInvoicePdf: (id: string, headers: AppHeaders, authorization?: string): Promise<Blob> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}/${id}/pdf`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                responseType: 'blob',
-            }),
-    },
-});
+export const invoiceList = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getInvoiceList: (
+                query: Request.GetInvoiceListBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.InvoiceListBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+            getInvoicePdf: (id: string, headers: AppHeaders, authorization?: string): Promise<Blob> =>
+                request({
+                    url: `${API_URL}/${id}/pdf`,
+                    responseType: 'blob',
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/billing/invoice-list/src/sdk/invoice-list.ts
+++ b/packages/blocks/billing/invoice-list/src/sdk/invoice-list.ts
@@ -24,7 +24,7 @@ export const invoiceList = (sdk: Sdk) => {
                 }),
             getInvoicePdf: (id: string, headers: AppHeaders, authorization?: string): Promise<Blob> =>
                 request({
-                    url: `${API_URL}/${id}/pdf`,
+                    url: `${API_URL}/${encodeURIComponent(id)}/pdf`,
                     responseType: 'blob',
                     headers,
                     authorization,

--- a/packages/blocks/billing/invoice-list/src/sdk/invoice-list.ts
+++ b/packages/blocks/billing/invoice-list/src/sdk/invoice-list.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/invoice-list.client';
 import { URL } from '../api-harmonization/invoice-list.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/invoice-list.url';
 const API_URL = URL;
 
 export const invoiceList = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/billing/payments-history/src/sdk/payments-history.ts
+++ b/packages/blocks/billing/payments-history/src/sdk/payments-history.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/payments-history.client';
 import { URL } from '../api-harmonization/payments-history.url';
 
 const API_URL = URL;
 
-export const paymentsHistory = (sdk: Sdk) => ({
-    blocks: {
-        getPaymentsHistory: (
-            params: Request.GetPaymentsHistoryBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.PaymentsHistoryBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params,
-            }),
-    },
-});
+export const paymentsHistory = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getPaymentsHistory: (
+                params: Request.GetPaymentsHistoryBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.PaymentsHistoryBlock> =>
+                request({
+                    url: API_URL,
+                    params,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/billing/payments-history/src/sdk/payments-history.ts
+++ b/packages/blocks/billing/payments-history/src/sdk/payments-history.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/payments-history.client';
 import { URL } from '../api-harmonization/payments-history.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/payments-history.url';
 const API_URL = URL;
 
 export const paymentsHistory = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/billing/payments-summary/src/sdk/payments-summary.ts
+++ b/packages/blocks/billing/payments-summary/src/sdk/payments-summary.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/payments-summary.client';
 import { URL } from '../api-harmonization/payments-summary.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/payments-summary.url';
 const API_URL = URL;
 
 export const paymentsSummary = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/billing/payments-summary/src/sdk/payments-summary.ts
+++ b/packages/blocks/billing/payments-summary/src/sdk/payments-summary.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/payments-summary.client';
 import { URL } from '../api-harmonization/payments-summary.url';
 
 const API_URL = URL;
 
-export const paymentsSummary = (sdk: Sdk) => ({
-    blocks: {
-        getPaymentsSummary: (
-            query: Request.GetPaymentsSummaryBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.PaymentsSummaryBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const paymentsSummary = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getPaymentsSummary: (
+                query: Request.GetPaymentsSummaryBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.PaymentsSummaryBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/checkout/cart/src/sdk/cart.ts
+++ b/packages/blocks/checkout/cart/src/sdk/cart.ts
@@ -32,7 +32,7 @@ export const cart = (sdk: Sdk) => {
                 authorization?: string,
             ): Promise<Carts.Model.Cart> =>
                 request({
-                    url: `${CARTS_API_URL}/${cartId}`,
+                    url: `${CARTS_API_URL}/${encodeURIComponent(cartId)}`,
                     headers,
                     authorization,
                 }),
@@ -46,7 +46,7 @@ export const cart = (sdk: Sdk) => {
             ): Promise<Carts.Model.Cart> =>
                 request({
                     method: 'patch',
-                    url: `${CARTS_API_URL}/${cartId}/items/${itemId}`,
+                    url: `${CARTS_API_URL}/${encodeURIComponent(cartId)}/items/${encodeURIComponent(itemId)}`,
                     data: body,
                     headers,
                     authorization,
@@ -60,7 +60,7 @@ export const cart = (sdk: Sdk) => {
             ): Promise<Carts.Model.Cart> =>
                 request({
                     method: 'delete',
-                    url: `${CARTS_API_URL}/${cartId}/items/${itemId}`,
+                    url: `${CARTS_API_URL}/${encodeURIComponent(cartId)}/items/${encodeURIComponent(itemId)}`,
                     headers,
                     authorization,
                 }),

--- a/packages/blocks/checkout/cart/src/sdk/cart.ts
+++ b/packages/blocks/checkout/cart/src/sdk/cart.ts
@@ -1,84 +1,69 @@
 import { Models } from '@o2s/utils.api-harmonization';
-import { Utils } from '@o2s/utils.frontend';
 
 import { Carts } from '@o2s/framework/modules';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/cart.client';
 
 const API_URL = URL;
 const CARTS_API_URL = '/carts';
 
-export const cart = (sdk: Sdk) => ({
-    blocks: {
-        getCart: (
-            query: Request.GetCartBlockQuery,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Model.CartBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-    cart: {
-        getCart: (
-            cartId: string,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${CARTS_API_URL}/${cartId}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
-                },
-            }),
+export const cart = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
 
-        updateCartItem: (
-            cartId: string,
-            itemId: string,
-            body: { quantity?: number; metadata?: Record<string, unknown>; locale?: string },
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'patch',
-                url: `${CARTS_API_URL}/${cartId}/items/${itemId}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
-                },
-                data: body,
-            }),
+    return {
+        blocks: {
+            getCart: (
+                query: Request.GetCartBlockQuery,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Model.CartBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+        cart: {
+            getCart: (
+                cartId: string,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    url: `${CARTS_API_URL}/${cartId}`,
+                    headers,
+                    authorization,
+                }),
 
-        removeCartItem: (
-            cartId: string,
-            itemId: string,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'delete',
-                url: `${CARTS_API_URL}/${cartId}/items/${itemId}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
-                },
-            }),
-    },
-});
+            updateCartItem: (
+                cartId: string,
+                itemId: string,
+                body: { quantity?: number; metadata?: Record<string, unknown>; locale?: string },
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    method: 'patch',
+                    url: `${CARTS_API_URL}/${cartId}/items/${itemId}`,
+                    data: body,
+                    headers,
+                    authorization,
+                }),
+
+            removeCartItem: (
+                cartId: string,
+                itemId: string,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    method: 'delete',
+                    url: `${CARTS_API_URL}/${cartId}/items/${itemId}`,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/checkout/cart/src/sdk/cart.ts
+++ b/packages/blocks/checkout/cart/src/sdk/cart.ts
@@ -1,7 +1,7 @@
 import { Models } from '@o2s/utils.api-harmonization';
 
 import { Carts } from '@o2s/framework/modules';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/cart.client';
 
@@ -9,7 +9,7 @@ const API_URL = URL;
 const CARTS_API_URL = '/carts';
 
 export const cart = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/checkout/checkout-billing-payment/src/sdk/checkout-billing-payment.ts
+++ b/packages/blocks/checkout/checkout-billing-payment/src/sdk/checkout-billing-payment.ts
@@ -1,7 +1,7 @@
 import { Models } from '@o2s/utils.api-harmonization';
 
 import { Carts, Checkout, Payments } from '@o2s/framework/modules';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/checkout-billing-payment.client';
 
@@ -11,7 +11,7 @@ const CHECKOUT_API_URL = '/checkout';
 const PAYMENTS_API_URL = '/payments';
 
 export const checkoutBillingPayment = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/checkout/checkout-billing-payment/src/sdk/checkout-billing-payment.ts
+++ b/packages/blocks/checkout/checkout-billing-payment/src/sdk/checkout-billing-payment.ts
@@ -34,7 +34,7 @@ export const checkoutBillingPayment = (sdk: Sdk) => {
                 authorization?: string,
             ): Promise<Carts.Model.Cart> =>
                 request({
-                    url: `${CARTS_API_URL}/${cartId}`,
+                    url: `${CARTS_API_URL}/${encodeURIComponent(cartId)}`,
                     headers,
                     authorization,
                 }),
@@ -48,7 +48,7 @@ export const checkoutBillingPayment = (sdk: Sdk) => {
             ): Promise<Payments.Model.PaymentSession> =>
                 request({
                     method: 'post',
-                    url: `${CHECKOUT_API_URL}/${cartId}/payment`,
+                    url: `${CHECKOUT_API_URL}/${encodeURIComponent(cartId)}/payment`,
                     data: body,
                     headers,
                     authorization,

--- a/packages/blocks/checkout/checkout-billing-payment/src/sdk/checkout-billing-payment.ts
+++ b/packages/blocks/checkout/checkout-billing-payment/src/sdk/checkout-billing-payment.ts
@@ -1,8 +1,7 @@
 import { Models } from '@o2s/utils.api-harmonization';
-import { Utils } from '@o2s/utils.frontend';
 
 import { Carts, Checkout, Payments } from '@o2s/framework/modules';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/checkout-billing-payment.client';
 
@@ -11,89 +10,62 @@ const CARTS_API_URL = '/carts';
 const CHECKOUT_API_URL = '/checkout';
 const PAYMENTS_API_URL = '/payments';
 
-export const checkoutBillingPayment = (sdk: Sdk) => ({
-    blocks: {
-        getCheckoutBillingPayment: (
-            query: Request.GetCheckoutBillingPaymentBlockQuery,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Model.CheckoutBillingPaymentBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-    carts: {
-        getCart: (
-            cartId: string,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${CARTS_API_URL}/${cartId}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-            }),
-    },
-    checkout: {
-        setPayment: (
-            cartId: string,
-            body: Checkout.Request.SetPaymentBody,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Payments.Model.PaymentSession> =>
-            sdk.makeRequest({
-                method: 'post',
-                url: `${CHECKOUT_API_URL}/${cartId}/payment`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                data: body,
-            }),
-    },
-    payments: {
-        getProviders: (
-            params: Payments.Request.GetProvidersParams,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Payments.Model.PaymentProviders> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${PAYMENTS_API_URL}/providers`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params,
-            }),
-    },
-});
+export const checkoutBillingPayment = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getCheckoutBillingPayment: (
+                query: Request.GetCheckoutBillingPaymentBlockQuery,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Model.CheckoutBillingPaymentBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+        carts: {
+            getCart: (
+                cartId: string,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    url: `${CARTS_API_URL}/${cartId}`,
+                    headers,
+                    authorization,
+                }),
+        },
+        checkout: {
+            setPayment: (
+                cartId: string,
+                body: Checkout.Request.SetPaymentBody,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Payments.Model.PaymentSession> =>
+                request({
+                    method: 'post',
+                    url: `${CHECKOUT_API_URL}/${cartId}/payment`,
+                    data: body,
+                    headers,
+                    authorization,
+                }),
+        },
+        payments: {
+            getProviders: (
+                params: Payments.Request.GetProvidersParams,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Payments.Model.PaymentProviders> =>
+                request({
+                    url: `${PAYMENTS_API_URL}/providers`,
+                    params,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/checkout/checkout-company-data/src/sdk/checkout-company-data.ts
+++ b/packages/blocks/checkout/checkout-company-data/src/sdk/checkout-company-data.ts
@@ -33,7 +33,7 @@ export const checkoutCompanyData = (sdk: Sdk) => {
                 authorization?: string,
             ): Promise<Carts.Model.Cart> =>
                 request({
-                    url: `${CARTS_API_URL}/${cartId}`,
+                    url: `${CARTS_API_URL}/${encodeURIComponent(cartId)}`,
                     headers,
                     authorization,
                 }),
@@ -47,7 +47,7 @@ export const checkoutCompanyData = (sdk: Sdk) => {
             ): Promise<Carts.Model.Cart> =>
                 request({
                     method: 'post',
-                    url: `${CHECKOUT_API_URL}/${cartId}/addresses`,
+                    url: `${CHECKOUT_API_URL}/${encodeURIComponent(cartId)}/addresses`,
                     data: body,
                     headers,
                     authorization,

--- a/packages/blocks/checkout/checkout-company-data/src/sdk/checkout-company-data.ts
+++ b/packages/blocks/checkout/checkout-company-data/src/sdk/checkout-company-data.ts
@@ -1,7 +1,7 @@
 import { Models } from '@o2s/utils.api-harmonization';
 
 import { Carts, Checkout } from '@o2s/framework/modules';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/checkout-company-data.client';
 
@@ -10,7 +10,7 @@ const CARTS_API_URL = '/carts';
 const CHECKOUT_API_URL = '/checkout';
 
 export const checkoutCompanyData = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/checkout/checkout-company-data/src/sdk/checkout-company-data.ts
+++ b/packages/blocks/checkout/checkout-company-data/src/sdk/checkout-company-data.ts
@@ -1,8 +1,7 @@
 import { Models } from '@o2s/utils.api-harmonization';
-import { Utils } from '@o2s/utils.frontend';
 
 import { Carts, Checkout } from '@o2s/framework/modules';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/checkout-company-data.client';
 
@@ -10,68 +9,49 @@ const API_URL = URL;
 const CARTS_API_URL = '/carts';
 const CHECKOUT_API_URL = '/checkout';
 
-export const checkoutCompanyData = (sdk: Sdk) => ({
-    blocks: {
-        getCheckoutCompanyData: (
-            query: Request.GetCheckoutCompanyDataBlockQuery,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Model.CheckoutCompanyDataBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-    carts: {
-        getCart: (
-            cartId: string,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${CARTS_API_URL}/${cartId}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-            }),
-    },
-    checkout: {
-        setAddresses: (
-            cartId: string,
-            body: Checkout.Request.SetAddressesBody,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'post',
-                url: `${CHECKOUT_API_URL}/${cartId}/addresses`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                data: body,
-            }),
-    },
-});
+export const checkoutCompanyData = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getCheckoutCompanyData: (
+                query: Request.GetCheckoutCompanyDataBlockQuery,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Model.CheckoutCompanyDataBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+        carts: {
+            getCart: (
+                cartId: string,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    url: `${CARTS_API_URL}/${cartId}`,
+                    headers,
+                    authorization,
+                }),
+        },
+        checkout: {
+            setAddresses: (
+                cartId: string,
+                body: Checkout.Request.SetAddressesBody,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    method: 'post',
+                    url: `${CHECKOUT_API_URL}/${cartId}/addresses`,
+                    data: body,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/checkout/checkout-shipping-address/src/sdk/checkout-shipping-address.ts
+++ b/packages/blocks/checkout/checkout-shipping-address/src/sdk/checkout-shipping-address.ts
@@ -1,7 +1,7 @@
 import { Models } from '@o2s/utils.api-harmonization';
 
 import { Carts, Checkout } from '@o2s/framework/modules';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/checkout-shipping-address.client';
 
@@ -10,7 +10,7 @@ const CARTS_API_URL = '/carts';
 const CHECKOUT_API_URL = '/checkout';
 
 export const checkoutShippingAddress = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/checkout/checkout-shipping-address/src/sdk/checkout-shipping-address.ts
+++ b/packages/blocks/checkout/checkout-shipping-address/src/sdk/checkout-shipping-address.ts
@@ -1,8 +1,7 @@
 import { Models } from '@o2s/utils.api-harmonization';
-import { Utils } from '@o2s/utils.frontend';
 
 import { Carts, Checkout } from '@o2s/framework/modules';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/checkout-shipping-address.client';
 
@@ -10,106 +9,72 @@ const API_URL = URL;
 const CARTS_API_URL = '/carts';
 const CHECKOUT_API_URL = '/checkout';
 
-export const checkoutShippingAddress = (sdk: Sdk) => ({
-    blocks: {
-        getCheckoutShippingAddress: (
-            query: Request.GetCheckoutShippingAddressBlockQuery,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Model.CheckoutShippingAddressBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-    carts: {
-        getCart: (
-            cartId: string,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${CARTS_API_URL}/${cartId}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-            }),
-    },
-    checkout: {
-        setAddresses: (
-            cartId: string,
-            body: Checkout.Request.SetAddressesBody,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'post',
-                url: `${CHECKOUT_API_URL}/${cartId}/addresses`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                data: body,
-            }),
-        setShippingMethod: (
-            cartId: string,
-            body: Checkout.Request.SetShippingMethodBody,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'post',
-                url: `${CHECKOUT_API_URL}/${cartId}/shipping-method`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                data: body,
-            }),
-        getShippingOptions: (
-            cartId: string,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Checkout.Model.ShippingOptions> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${CHECKOUT_API_URL}/${cartId}/shipping-options`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-            }),
-    },
-});
+export const checkoutShippingAddress = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getCheckoutShippingAddress: (
+                query: Request.GetCheckoutShippingAddressBlockQuery,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Model.CheckoutShippingAddressBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+        carts: {
+            getCart: (
+                cartId: string,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    url: `${CARTS_API_URL}/${cartId}`,
+                    headers,
+                    authorization,
+                }),
+        },
+        checkout: {
+            setAddresses: (
+                cartId: string,
+                body: Checkout.Request.SetAddressesBody,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    method: 'post',
+                    url: `${CHECKOUT_API_URL}/${cartId}/addresses`,
+                    data: body,
+                    headers,
+                    authorization,
+                }),
+            setShippingMethod: (
+                cartId: string,
+                body: Checkout.Request.SetShippingMethodBody,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    method: 'post',
+                    url: `${CHECKOUT_API_URL}/${cartId}/shipping-method`,
+                    data: body,
+                    headers,
+                    authorization,
+                }),
+            getShippingOptions: (
+                cartId: string,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Checkout.Model.ShippingOptions> =>
+                request({
+                    url: `${CHECKOUT_API_URL}/${cartId}/shipping-options`,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/checkout/checkout-shipping-address/src/sdk/checkout-shipping-address.ts
+++ b/packages/blocks/checkout/checkout-shipping-address/src/sdk/checkout-shipping-address.ts
@@ -33,7 +33,7 @@ export const checkoutShippingAddress = (sdk: Sdk) => {
                 authorization?: string,
             ): Promise<Carts.Model.Cart> =>
                 request({
-                    url: `${CARTS_API_URL}/${cartId}`,
+                    url: `${CARTS_API_URL}/${encodeURIComponent(cartId)}`,
                     headers,
                     authorization,
                 }),
@@ -47,7 +47,7 @@ export const checkoutShippingAddress = (sdk: Sdk) => {
             ): Promise<Carts.Model.Cart> =>
                 request({
                     method: 'post',
-                    url: `${CHECKOUT_API_URL}/${cartId}/addresses`,
+                    url: `${CHECKOUT_API_URL}/${encodeURIComponent(cartId)}/addresses`,
                     data: body,
                     headers,
                     authorization,
@@ -60,7 +60,7 @@ export const checkoutShippingAddress = (sdk: Sdk) => {
             ): Promise<Carts.Model.Cart> =>
                 request({
                     method: 'post',
-                    url: `${CHECKOUT_API_URL}/${cartId}/shipping-method`,
+                    url: `${CHECKOUT_API_URL}/${encodeURIComponent(cartId)}/shipping-method`,
                     data: body,
                     headers,
                     authorization,
@@ -71,7 +71,7 @@ export const checkoutShippingAddress = (sdk: Sdk) => {
                 authorization?: string,
             ): Promise<Checkout.Model.ShippingOptions> =>
                 request({
-                    url: `${CHECKOUT_API_URL}/${cartId}/shipping-options`,
+                    url: `${CHECKOUT_API_URL}/${encodeURIComponent(cartId)}/shipping-options`,
                     headers,
                     authorization,
                 }),

--- a/packages/blocks/checkout/checkout-summary/src/sdk/checkout-summary.ts
+++ b/packages/blocks/checkout/checkout-summary/src/sdk/checkout-summary.ts
@@ -1,74 +1,54 @@
 import { Models } from '@o2s/utils.api-harmonization';
-import { Utils } from '@o2s/utils.frontend';
 
 import { Checkout } from '@o2s/framework/modules';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/checkout-summary.client';
 
 const API_URL = URL;
 const CHECKOUT_API_URL = '/checkout';
 
-export const checkoutSummary = (sdk: Sdk) => ({
-    blocks: {
-        getCheckoutSummary: (
-            query: Request.GetCheckoutSummaryBlockQuery,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Model.CheckoutSummaryBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-    checkout: {
-        getCheckoutSummary: (
-            cartId: string,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Checkout.Model.CheckoutSummary> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${CHECKOUT_API_URL}/${cartId}/summary`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-            }),
-        placeOrder: (
-            cartId: string,
-            body: Checkout.Request.PlaceOrderBody,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Checkout.Model.PlaceOrderResponse> =>
-            sdk.makeRequest({
-                method: 'post',
-                url: `${CHECKOUT_API_URL}/${cartId}/place-order`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                data: body,
-            }),
-    },
-});
+export const checkoutSummary = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getCheckoutSummary: (
+                query: Request.GetCheckoutSummaryBlockQuery,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Model.CheckoutSummaryBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+        checkout: {
+            getCheckoutSummary: (
+                cartId: string,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Checkout.Model.CheckoutSummary> =>
+                request({
+                    url: `${CHECKOUT_API_URL}/${cartId}/summary`,
+                    headers,
+                    authorization,
+                }),
+            placeOrder: (
+                cartId: string,
+                body: Checkout.Request.PlaceOrderBody,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Checkout.Model.PlaceOrderResponse> =>
+                request({
+                    method: 'post',
+                    url: `${CHECKOUT_API_URL}/${cartId}/place-order`,
+                    data: body,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/checkout/checkout-summary/src/sdk/checkout-summary.ts
+++ b/packages/blocks/checkout/checkout-summary/src/sdk/checkout-summary.ts
@@ -32,7 +32,7 @@ export const checkoutSummary = (sdk: Sdk) => {
                 authorization?: string,
             ): Promise<Checkout.Model.CheckoutSummary> =>
                 request({
-                    url: `${CHECKOUT_API_URL}/${cartId}/summary`,
+                    url: `${CHECKOUT_API_URL}/${encodeURIComponent(cartId)}/summary`,
                     headers,
                     authorization,
                 }),
@@ -44,7 +44,7 @@ export const checkoutSummary = (sdk: Sdk) => {
             ): Promise<Checkout.Model.PlaceOrderResponse> =>
                 request({
                     method: 'post',
-                    url: `${CHECKOUT_API_URL}/${cartId}/place-order`,
+                    url: `${CHECKOUT_API_URL}/${encodeURIComponent(cartId)}/place-order`,
                     data: body,
                     headers,
                     authorization,

--- a/packages/blocks/checkout/checkout-summary/src/sdk/checkout-summary.ts
+++ b/packages/blocks/checkout/checkout-summary/src/sdk/checkout-summary.ts
@@ -1,7 +1,7 @@
 import { Models } from '@o2s/utils.api-harmonization';
 
 import { Checkout } from '@o2s/framework/modules';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/checkout-summary.client';
 
@@ -9,7 +9,7 @@ const API_URL = URL;
 const CHECKOUT_API_URL = '/checkout';
 
 export const checkoutSummary = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/checkout/order-confirmation/src/sdk/order-confirmation.ts
+++ b/packages/blocks/checkout/order-confirmation/src/sdk/order-confirmation.ts
@@ -1,13 +1,13 @@
 import { Models } from '@o2s/utils.api-harmonization';
 
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/order-confirmation.client';
 
 const API_URL = URL;
 
 export const orderConfirmation = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/checkout/order-confirmation/src/sdk/order-confirmation.ts
+++ b/packages/blocks/checkout/order-confirmation/src/sdk/order-confirmation.ts
@@ -1,32 +1,27 @@
 import { Models } from '@o2s/utils.api-harmonization';
-import { Utils } from '@o2s/utils.frontend';
 
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/order-confirmation.client';
 
 const API_URL = URL;
 
-export const orderConfirmation = (sdk: Sdk) => ({
-    blocks: {
-        getOrderConfirmation: (
-            query: Request.GetOrderConfirmationBlockQuery,
-            headers: Models.Headers.AppHeaders,
-            authorization?: string,
-        ): Promise<Model.OrderConfirmationBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const orderConfirmation = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getOrderConfirmation: (
+                query: Request.GetOrderConfirmationBlockQuery,
+                headers: Models.Headers.AppHeaders,
+                authorization?: string,
+            ): Promise<Model.OrderConfirmationBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/bento-grid/src/sdk/bento-grid.ts
+++ b/packages/blocks/content/bento-grid/src/sdk/bento-grid.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/bento-grid.client';
 import { URL } from '../api-harmonization/bento-grid.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/bento-grid.url';
 const API_URL = URL;
 
 export const bentoGrid = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/content/bento-grid/src/sdk/bento-grid.ts
+++ b/packages/blocks/content/bento-grid/src/sdk/bento-grid.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/bento-grid.client';
 import { URL } from '../api-harmonization/bento-grid.url';
 
 const API_URL = URL;
 
-export const bentoGrid = (sdk: Sdk) => ({
-    blocks: {
-        getBentoGrid: (
-            query: Request.GetBentoGridBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.BentoGridBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const bentoGrid = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getBentoGrid: (
+                query: Request.GetBentoGridBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.BentoGridBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/cta-section/src/sdk/cta-section.ts
+++ b/packages/blocks/content/cta-section/src/sdk/cta-section.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/cta-section.client';
 import { URL } from '../api-harmonization/cta-section.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/cta-section.url';
 const API_URL = URL;
 
 export const ctaSection = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/content/cta-section/src/sdk/cta-section.ts
+++ b/packages/blocks/content/cta-section/src/sdk/cta-section.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/cta-section.client';
 import { URL } from '../api-harmonization/cta-section.url';
 
 const API_URL = URL;
 
-export const ctaSection = (sdk: Sdk) => ({
-    blocks: {
-        getCtaSection: (
-            query: Request.GetCtaSectionBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.CtaSectionBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const ctaSection = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getCtaSection: (
+                query: Request.GetCtaSectionBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.CtaSectionBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/document-list/src/sdk/document-list.ts
+++ b/packages/blocks/content/document-list/src/sdk/document-list.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/document-list.client';
 import { URL } from '../api-harmonization/document-list.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/document-list.url';
 const API_URL = URL;
 
 export const documentList = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/content/document-list/src/sdk/document-list.ts
+++ b/packages/blocks/content/document-list/src/sdk/document-list.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/document-list.client';
 import { URL } from '../api-harmonization/document-list.url';
 
 const API_URL = URL;
 
-export const documentList = (sdk: Sdk) => ({
-    blocks: {
-        getDocumentList: (
-            query: Request.GetDocumentListBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.DocumentListBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const documentList = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getDocumentList: (
+                query: Request.GetDocumentListBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.DocumentListBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/faq/src/sdk/faq.ts
+++ b/packages/blocks/content/faq/src/sdk/faq.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/faq.client';
 import { URL } from '../api-harmonization/faq.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/faq.url';
 const API_URL = URL;
 
 export const faq = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/content/faq/src/sdk/faq.ts
+++ b/packages/blocks/content/faq/src/sdk/faq.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/faq.client';
 import { URL } from '../api-harmonization/faq.url';
 
 const API_URL = URL;
 
-export const faq = (sdk: Sdk) => ({
-    blocks: {
-        getFaq: (
-            query: Request.GetFaqBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.FaqBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const faq = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getFaq: (
+                query: Request.GetFaqBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.FaqBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/feature-section-grid/src/sdk/feature-section-grid.ts
+++ b/packages/blocks/content/feature-section-grid/src/sdk/feature-section-grid.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/feature-section-grid.client';
 import { URL } from '../api-harmonization/feature-section-grid.url';
 
 const API_URL = URL;
 
-export const featureSectionGrid = (sdk: Sdk) => ({
-    blocks: {
-        getFeatureSectionGrid: (
-            query: Request.GetFeatureSectionGridBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.FeatureSectionGridBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const featureSectionGrid = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getFeatureSectionGrid: (
+                query: Request.GetFeatureSectionGridBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.FeatureSectionGridBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/feature-section-grid/src/sdk/feature-section-grid.ts
+++ b/packages/blocks/content/feature-section-grid/src/sdk/feature-section-grid.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/feature-section-grid.client';
 import { URL } from '../api-harmonization/feature-section-grid.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/feature-section-grid.url';
 const API_URL = URL;
 
 export const featureSectionGrid = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/content/feature-section/src/sdk/feature-section.ts
+++ b/packages/blocks/content/feature-section/src/sdk/feature-section.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/feature-section.client';
 import { URL } from '../api-harmonization/feature-section.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/feature-section.url';
 const API_URL = URL;
 
 export const featureSection = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/content/feature-section/src/sdk/feature-section.ts
+++ b/packages/blocks/content/feature-section/src/sdk/feature-section.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/feature-section.client';
 import { URL } from '../api-harmonization/feature-section.url';
 
 const API_URL = URL;
 
-export const featureSection = (sdk: Sdk) => ({
-    blocks: {
-        getFeatureSection: (
-            query: Request.GetFeatureSectionBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.FeatureSectionBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const featureSection = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getFeatureSection: (
+                query: Request.GetFeatureSectionBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.FeatureSectionBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/hero-section/src/sdk/hero-section.ts
+++ b/packages/blocks/content/hero-section/src/sdk/hero-section.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/hero-section.client';
 import { URL } from '../api-harmonization/hero-section.url';
 
 const API_URL = URL;
 
-export const heroSection = (sdk: Sdk) => ({
-    blocks: {
-        getHeroSection: (
-            query: Request.GetHeroSectionBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.HeroSectionBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const heroSection = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getHeroSection: (
+                query: Request.GetHeroSectionBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.HeroSectionBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/hero-section/src/sdk/hero-section.ts
+++ b/packages/blocks/content/hero-section/src/sdk/hero-section.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/hero-section.client';
 import { URL } from '../api-harmonization/hero-section.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/hero-section.url';
 const API_URL = URL;
 
 export const heroSection = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/content/media-section/src/sdk/media-section.ts
+++ b/packages/blocks/content/media-section/src/sdk/media-section.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/media-section.client';
 import { URL } from '../api-harmonization/media-section.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/media-section.url';
 const API_URL = URL;
 
 export const mediaSection = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/content/media-section/src/sdk/media-section.ts
+++ b/packages/blocks/content/media-section/src/sdk/media-section.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/media-section.client';
 import { URL } from '../api-harmonization/media-section.url';
 
 const API_URL = URL;
 
-export const mediaSection = (sdk: Sdk) => ({
-    blocks: {
-        getMediaSection: (
-            query: Request.GetMediaSectionBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.MediaSectionBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const mediaSection = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getMediaSection: (
+                query: Request.GetMediaSectionBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.MediaSectionBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/pricing-section/src/sdk/pricing-section.ts
+++ b/packages/blocks/content/pricing-section/src/sdk/pricing-section.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/pricing-section.client';
 import { URL } from '../api-harmonization/pricing-section.url';
 
 const API_URL = URL;
 
-export const pricingSection = (sdk: Sdk) => ({
-    blocks: {
-        getPricingSection: (
-            query: Request.GetPricingSectionBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.PricingSectionBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const pricingSection = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getPricingSection: (
+                query: Request.GetPricingSectionBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.PricingSectionBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/pricing-section/src/sdk/pricing-section.ts
+++ b/packages/blocks/content/pricing-section/src/sdk/pricing-section.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/pricing-section.client';
 import { URL } from '../api-harmonization/pricing-section.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/pricing-section.url';
 const API_URL = URL;
 
 export const pricingSection = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/content/quick-links/src/sdk/quick-links.ts
+++ b/packages/blocks/content/quick-links/src/sdk/quick-links.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/quick-links.client';
 import { URL } from '../api-harmonization/quick-links.url';
 
 const API_URL = URL;
 
-export const quickLinks = (sdk: Sdk) => ({
-    blocks: {
-        getQuickLinks: (
-            query: Request.GetQuickLinksBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.QuickLinksBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const quickLinks = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getQuickLinks: (
+                query: Request.GetQuickLinksBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.QuickLinksBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/content/quick-links/src/sdk/quick-links.ts
+++ b/packages/blocks/content/quick-links/src/sdk/quick-links.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/quick-links.client';
 import { URL } from '../api-harmonization/quick-links.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/quick-links.url';
 const API_URL = URL;
 
 export const quickLinks = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/forms/surveyjs-form/src/sdk/surveyjs.ts
+++ b/packages/blocks/forms/surveyjs-form/src/sdk/surveyjs.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/surveyjs.client';
 import { URL } from '../api-harmonization/surveyjs.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/surveyjs.url';
 const API_URL = URL;
 
 export const surveyjs = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/forms/surveyjs-form/src/sdk/surveyjs.ts
+++ b/packages/blocks/forms/surveyjs-form/src/sdk/surveyjs.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/surveyjs.client';
 import { URL } from '../api-harmonization/surveyjs.url';
 
 const API_URL = URL;
 
-export const surveyjs = (sdk: Sdk) => ({
-    blocks: {
-        getSurveyjsBlock: (
-            query: Request.GetSurveyjsBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.SurveyjsBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const surveyjs = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getSurveyjsBlock: (
+                query: Request.GetSurveyjsBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.SurveyjsBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/knowledge-base/article-list/src/sdk/article-list.ts
+++ b/packages/blocks/knowledge-base/article-list/src/sdk/article-list.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/article-list.client';
 import { URL } from '../api-harmonization/article-list.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/article-list.url';
 const API_URL = URL;
 
 export const articleList = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/knowledge-base/article-list/src/sdk/article-list.ts
+++ b/packages/blocks/knowledge-base/article-list/src/sdk/article-list.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/article-list.client';
 import { URL } from '../api-harmonization/article-list.url';
 
 const API_URL = URL;
 
-export const articleList = (sdk: Sdk) => ({
-    blocks: {
-        getArticleList: (
-            query: Request.GetArticleListBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.ArticleListBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const articleList = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getArticleList: (
+                query: Request.GetArticleListBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.ArticleListBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/knowledge-base/article-search/src/sdk/article-search.ts
+++ b/packages/blocks/knowledge-base/article-search/src/sdk/article-search.ts
@@ -1,52 +1,38 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/article-search.client';
 import { URL } from '../api-harmonization/article-search.url';
 
 const API_URL = URL;
 
-export const articleSearch = (sdk: Sdk) => ({
-    blocks: {
-        getArticleSearch: (
-            query: Request.GetArticleSearchBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.ArticleSearchBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-        searchArticles: (
-            query: Request.SearchArticlesQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.ArticleList> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}/articles`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const articleSearch = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getArticleSearch: (
+                query: Request.GetArticleSearchBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.ArticleSearchBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+            searchArticles: (
+                query: Request.SearchArticlesQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.ArticleList> =>
+                request({
+                    url: `${API_URL}/articles`,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/knowledge-base/article-search/src/sdk/article-search.ts
+++ b/packages/blocks/knowledge-base/article-search/src/sdk/article-search.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/article-search.client';
 import { URL } from '../api-harmonization/article-search.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/article-search.url';
 const API_URL = URL;
 
 export const articleSearch = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/knowledge-base/article/src/sdk/article.ts
+++ b/packages/blocks/knowledge-base/article/src/sdk/article.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/article.client';
 import { URL } from '../api-harmonization/article.url';
 
 const API_URL = URL;
 
-export const article = (sdk: Sdk) => ({
-    blocks: {
-        getArticle: (
-            query: Request.GetArticleBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.ArticleBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const article = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getArticle: (
+                query: Request.GetArticleBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.ArticleBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/knowledge-base/article/src/sdk/article.ts
+++ b/packages/blocks/knowledge-base/article/src/sdk/article.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/article.client';
 import { URL } from '../api-harmonization/article.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/article.url';
 const API_URL = URL;
 
 export const article = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/knowledge-base/category-list/src/sdk/category-list.ts
+++ b/packages/blocks/knowledge-base/category-list/src/sdk/category-list.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/category-list.client';
 import { URL } from '../api-harmonization/category-list.url';
 
 const API_URL = URL;
 
-export const categoryList = (sdk: Sdk) => ({
-    blocks: {
-        getCategoryList: (
-            query: Request.GetCategoryListBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.CategoryListBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const categoryList = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getCategoryList: (
+                query: Request.GetCategoryListBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.CategoryListBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/knowledge-base/category-list/src/sdk/category-list.ts
+++ b/packages/blocks/knowledge-base/category-list/src/sdk/category-list.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/category-list.client';
 import { URL } from '../api-harmonization/category-list.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/category-list.url';
 const API_URL = URL;
 
 export const categoryList = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/knowledge-base/category/src/sdk/category.ts
+++ b/packages/blocks/knowledge-base/category/src/sdk/category.ts
@@ -1,52 +1,38 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/category.client';
 import { URL } from '../api-harmonization/category.url';
 
 const API_URL = URL;
 
-export const category = (sdk: Sdk) => ({
-    blocks: {
-        getCategory: (
-            query: Request.GetCategoryBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.CategoryBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-        getCategoryArticles: (
-            query: Request.GetCategoryBlockArticlesQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.CategoryArticles> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}/articles`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const category = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getCategory: (
+                query: Request.GetCategoryBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.CategoryBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+            getCategoryArticles: (
+                query: Request.GetCategoryBlockArticlesQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.CategoryArticles> =>
+                request({
+                    url: `${API_URL}/articles`,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/knowledge-base/category/src/sdk/category.ts
+++ b/packages/blocks/knowledge-base/category/src/sdk/category.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/category.client';
 import { URL } from '../api-harmonization/category.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/category.url';
 const API_URL = URL;
 
 export const category = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/notifications/notification-details/src/sdk/notification-details.ts
+++ b/packages/blocks/notifications/notification-details/src/sdk/notification-details.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/notification-details.client';
 import { URL } from '../api-harmonization/notification-details.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/notification-details.url';
 const API_URL = URL;
 
 export const notificationDetails = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/notifications/notification-details/src/sdk/notification-details.ts
+++ b/packages/blocks/notifications/notification-details/src/sdk/notification-details.ts
@@ -1,53 +1,40 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/notification-details.client';
 import { URL } from '../api-harmonization/notification-details.url';
 
 const API_URL = URL;
 
-export const notificationDetails = (sdk: Sdk) => ({
-    blocks: {
-        getNotificationDetails: (
-            params: Request.GetNotificationDetailsBlockParams,
-            query: Request.GetNotificationDetailsBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.NotificationDetailsBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}/${params.id}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-        markNotificationAs: (
-            body: Request.MarkNotificationAsBlockBody,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<void> =>
-            sdk.makeRequest({
-                method: 'post',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                data: body,
-            }),
-    },
-});
+export const notificationDetails = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getNotificationDetails: (
+                params: Request.GetNotificationDetailsBlockParams,
+                query: Request.GetNotificationDetailsBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.NotificationDetailsBlock> =>
+                request({
+                    url: `${API_URL}/${params.id}`,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+            markNotificationAs: (
+                body: Request.MarkNotificationAsBlockBody,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<void> =>
+                request({
+                    method: 'post',
+                    url: API_URL,
+                    data: body,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/notifications/notification-list/src/sdk/notification-list.ts
+++ b/packages/blocks/notifications/notification-list/src/sdk/notification-list.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/notification-list.client';
 import { URL } from '../api-harmonization/notification-list.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/notification-list.url';
 const API_URL = URL;
 
 export const notificationList = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/notifications/notification-list/src/sdk/notification-list.ts
+++ b/packages/blocks/notifications/notification-list/src/sdk/notification-list.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/notification-list.client';
 import { URL } from '../api-harmonization/notification-list.url';
 
 const API_URL = URL;
 
-export const notificationList = (sdk: Sdk) => ({
-    blocks: {
-        getNotificationList: (
-            query: Request.GetNotificationListBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.NotificationListBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const notificationList = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getNotificationList: (
+                query: Request.GetNotificationListBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.NotificationListBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/notifications/notification-summary/src/sdk/notification-summary.ts
+++ b/packages/blocks/notifications/notification-summary/src/sdk/notification-summary.ts
@@ -1,12 +1,12 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/notification-summary.client';
 
 const API_URL = URL;
 
 export const notificationSummary = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/notifications/notification-summary/src/sdk/notification-summary.ts
+++ b/packages/blocks/notifications/notification-summary/src/sdk/notification-summary.ts
@@ -1,32 +1,26 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/notification-summary.client';
 
 const API_URL = URL;
 
-export const notificationSummary = (sdk: Sdk) => ({
-    blocks: {
-        getNotificationSummary: (
-            query: Request.GetNotificationSummaryBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.NotificationSummaryBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const notificationSummary = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getNotificationSummary: (
+                query: Request.GetNotificationSummaryBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.NotificationSummaryBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/orders/order-details/src/sdk/order-details.ts
+++ b/packages/blocks/orders/order-details/src/sdk/order-details.ts
@@ -1,46 +1,38 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/order-details.client';
 import { URL } from '../api-harmonization/order-details.url';
 
 const API_URL = URL;
 
-export const orderDetails = (sdk: Sdk) => ({
-    blocks: {
-        getOrderDetails: (
-            params: Request.GetOrderDetailsBlockParams,
-            query: Request.GetOrderDetailsBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.OrderDetailsBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}/${params.id}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-        getOrderPdf: (id: string, headers: AppHeaders, authorization?: string): Promise<Blob> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}/documents/${id}/pdf`,
-                responseType: 'blob',
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    Authorization: `Bearer ${authorization}`,
-                    Accept: 'application/pdf',
-                },
-            }),
-    },
-});
+export const orderDetails = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getOrderDetails: (
+                params: Request.GetOrderDetailsBlockParams,
+                query: Request.GetOrderDetailsBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.OrderDetailsBlock> =>
+                request({
+                    url: `${API_URL}/${params.id}`,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+            getOrderPdf: (id: string, headers: AppHeaders, authorization?: string): Promise<Blob> =>
+                request({
+                    url: `${API_URL}/documents/${id}/pdf`,
+                    responseType: 'blob',
+                    headers: {
+                        ...headers,
+                        Accept: 'application/pdf',
+                    },
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/orders/order-details/src/sdk/order-details.ts
+++ b/packages/blocks/orders/order-details/src/sdk/order-details.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/order-details.client';
 import { URL } from '../api-harmonization/order-details.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/order-details.url';
 const API_URL = URL;
 
 export const orderDetails = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/orders/order-list/src/sdk/order-list.ts
+++ b/packages/blocks/orders/order-list/src/sdk/order-list.ts
@@ -1,31 +1,25 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/order-list.client';
 import { URL } from '../api-harmonization/order-list.url';
 
-export const orderList = (sdk: Sdk) => ({
-    blocks: {
-        getOrderList: (
-            query: Request.GetOrderListBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.OrderListBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const orderList = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getOrderList: (
+                query: Request.GetOrderListBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.OrderListBlock> =>
+                request({
+                    url: URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/orders/order-list/src/sdk/order-list.ts
+++ b/packages/blocks/orders/order-list/src/sdk/order-list.ts
@@ -1,11 +1,11 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/order-list.client';
 import { URL } from '../api-harmonization/order-list.url';
 
 export const orderList = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/orders/orders-summary/src/sdk/orders-summary.ts
+++ b/packages/blocks/orders/orders-summary/src/sdk/orders-summary.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/orders-summary.client';
 import { URL } from '../api-harmonization/orders-summary.url';
 
 const API_URL = URL;
 
-export const ordersSummary = (sdk: Sdk) => ({
-    blocks: {
-        getOrdersSummary: (
-            query: Request.GetOrdersSummaryBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.OrdersSummaryBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const ordersSummary = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getOrdersSummary: (
+                query: Request.GetOrdersSummaryBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.OrdersSummaryBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/orders/orders-summary/src/sdk/orders-summary.ts
+++ b/packages/blocks/orders/orders-summary/src/sdk/orders-summary.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/orders-summary.client';
 import { URL } from '../api-harmonization/orders-summary.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/orders-summary.url';
 const API_URL = URL;
 
 export const ordersSummary = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/products/product-details/src/sdk/product-details.ts
+++ b/packages/blocks/products/product-details/src/sdk/product-details.ts
@@ -1,54 +1,47 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
 import { Carts } from '@o2s/framework/modules';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/product-details.client';
 
 const CARTS_API_URL = '/carts';
 
-export const productDetails = (sdk: Sdk) => ({
-    blocks: {
-        getProductDetails: (
-            params: Request.GetProductDetailsBlockParams,
-            query?: Request.GetProductDetailsBlockQuery,
-            headers?: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.ProductDetailsBlock> => {
-            const urlPath = params.variantSlug ? `${URL}/${params.id}/${params.variantSlug}` : `${URL}/${params.id}`;
+export const productDetails = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
 
-            return sdk.makeRequest({
-                method: 'get',
-                url: urlPath,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            });
+    return {
+        blocks: {
+            getProductDetails: (
+                params: Request.GetProductDetailsBlockParams,
+                query?: Request.GetProductDetailsBlockQuery,
+                headers?: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.ProductDetailsBlock> => {
+                const urlPath = params.variantSlug
+                    ? `${URL}/${params.id}/${params.variantSlug}`
+                    : `${URL}/${params.id}`;
+
+                return request({
+                    url: urlPath,
+                    params: query,
+                    headers,
+                    authorization,
+                });
+            },
         },
-    },
-    cart: {
-        addCartItem: (
-            body: Carts.Request.AddCartItemBody,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'post',
-                url: `${CARTS_API_URL}/items`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
-                },
-                data: body,
-            }),
-    },
-});
+        cart: {
+            addCartItem: (
+                body: Carts.Request.AddCartItemBody,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    method: 'post',
+                    url: `${CARTS_API_URL}/items`,
+                    data: body,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/products/product-details/src/sdk/product-details.ts
+++ b/packages/blocks/products/product-details/src/sdk/product-details.ts
@@ -1,13 +1,13 @@
 import { AppHeaders } from '@o2s/framework/headers';
 import { Carts } from '@o2s/framework/modules';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/product-details.client';
 
 const CARTS_API_URL = '/carts';
 
 export const productDetails = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/products/product-list/src/sdk/product-list.ts
+++ b/packages/blocks/products/product-list/src/sdk/product-list.ts
@@ -1,8 +1,6 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
 import { Carts } from '@o2s/framework/modules';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/product-list.client';
 import { URL } from '../api-harmonization/product-list.url';
@@ -10,43 +8,36 @@ import { URL } from '../api-harmonization/product-list.url';
 const API_URL = URL;
 const CARTS_API_URL = '/carts';
 
-export const productList = (sdk: Sdk) => ({
-    blocks: {
-        getProductList: (
-            query: Request.GetProductListBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.ProductListBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-    cart: {
-        addCartItem: (
-            body: Carts.Request.AddCartItemBody,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'post',
-                url: `${CARTS_API_URL}/items`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
-                },
-                data: body,
-            }),
-    },
-});
+export const productList = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getProductList: (
+                query: Request.GetProductListBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.ProductListBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+        cart: {
+            addCartItem: (
+                body: Carts.Request.AddCartItemBody,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    method: 'post',
+                    url: `${CARTS_API_URL}/items`,
+                    data: body,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/products/product-list/src/sdk/product-list.ts
+++ b/packages/blocks/products/product-list/src/sdk/product-list.ts
@@ -1,6 +1,6 @@
 import { AppHeaders } from '@o2s/framework/headers';
 import { Carts } from '@o2s/framework/modules';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/product-list.client';
 import { URL } from '../api-harmonization/product-list.url';
@@ -9,7 +9,7 @@ const API_URL = URL;
 const CARTS_API_URL = '/carts';
 
 export const productList = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/products/recommended-products/src/sdk/recommended-products.ts
+++ b/packages/blocks/products/recommended-products/src/sdk/recommended-products.ts
@@ -1,54 +1,45 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
 import { Carts } from '@o2s/framework/modules';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/recommended-products.client';
 
 const CARTS_API_URL = '/carts';
 
-export const recommendedProducts = (sdk: Sdk) => ({
-    blocks: {
-        getRecommendedProducts: (
-            params: { id: string },
-            query?: Omit<Request.GetRecommendedProductsBlockQuery, 'id'>,
-            headers?: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.RecommendedProductsBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: {
-                    ...params,
-                    ...query,
-                },
-            }),
-    },
-    cart: {
-        addCartItem: (
-            body: Carts.Request.AddCartItemBody,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Carts.Model.Cart> =>
-            sdk.makeRequest({
-                method: 'post',
-                url: `${CARTS_API_URL}/items`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
-                },
-                data: body,
-            }),
-    },
-});
+export const recommendedProducts = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getRecommendedProducts: (
+                params: { id: string },
+                query?: Omit<Request.GetRecommendedProductsBlockQuery, 'id'>,
+                headers?: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.RecommendedProductsBlock> =>
+                request({
+                    url: URL,
+                    params: {
+                        ...params,
+                        ...query,
+                    },
+                    headers,
+                    authorization,
+                }),
+        },
+        cart: {
+            addCartItem: (
+                body: Carts.Request.AddCartItemBody,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Carts.Model.Cart> =>
+                request({
+                    method: 'post',
+                    url: `${CARTS_API_URL}/items`,
+                    data: body,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/products/recommended-products/src/sdk/recommended-products.ts
+++ b/packages/blocks/products/recommended-products/src/sdk/recommended-products.ts
@@ -1,13 +1,13 @@
 import { AppHeaders } from '@o2s/framework/headers';
 import { Carts } from '@o2s/framework/modules';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/recommended-products.client';
 
 const CARTS_API_URL = '/carts';
 
 export const recommendedProducts = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/services/featured-service-list/src/sdk/featured-service-list.ts
+++ b/packages/blocks/services/featured-service-list/src/sdk/featured-service-list.ts
@@ -1,12 +1,12 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/featured-service-list.client';
 
 const API_URL = URL;
 
 export const featuredServiceList = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/services/featured-service-list/src/sdk/featured-service-list.ts
+++ b/packages/blocks/services/featured-service-list/src/sdk/featured-service-list.ts
@@ -1,32 +1,26 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/featured-service-list.client';
 
 const API_URL = URL;
 
-export const featuredServiceList = (sdk: Sdk) => ({
-    blocks: {
-        getFeaturedServiceList: (
-            query: Request.GetFeaturedServiceListBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.FeaturedServiceListBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const featuredServiceList = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getFeaturedServiceList: (
+                query: Request.GetFeaturedServiceListBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.FeaturedServiceListBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/services/service-details/src/sdk/service-details.ts
+++ b/packages/blocks/services/service-details/src/sdk/service-details.ts
@@ -1,34 +1,28 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/service-details.client';
 import { URL } from '../api-harmonization/service-details.url';
 
 const API_URL = URL;
 
-export const serviceDetails = (sdk: Sdk) => ({
-    blocks: {
-        getServiceDetails: (
-            params: Request.GetServiceDetailsBlockParams,
-            query: Request.GetServiceDetailsBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.ServiceDetailsBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}/${params.id}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const serviceDetails = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getServiceDetails: (
+                params: Request.GetServiceDetailsBlockParams,
+                query: Request.GetServiceDetailsBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.ServiceDetailsBlock> =>
+                request({
+                    url: `${API_URL}/${params.id}`,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/services/service-details/src/sdk/service-details.ts
+++ b/packages/blocks/services/service-details/src/sdk/service-details.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/service-details.client';
 import { URL } from '../api-harmonization/service-details.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/service-details.url';
 const API_URL = URL;
 
 export const serviceDetails = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/services/service-list/src/sdk/service-list.ts
+++ b/packages/blocks/services/service-list/src/sdk/service-list.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/service-list.client';
 import { URL } from '../api-harmonization/service-list.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/service-list.url';
 const API_URL = URL;
 
 export const serviceList = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/services/service-list/src/sdk/service-list.ts
+++ b/packages/blocks/services/service-list/src/sdk/service-list.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/service-list.client';
 import { URL } from '../api-harmonization/service-list.url';
 
 const API_URL = URL;
 
-export const serviceList = (sdk: Sdk) => ({
-    blocks: {
-        getServiceList: (
-            query: Request.GetServiceListBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.ServiceListBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const serviceList = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getServiceList: (
+                query: Request.GetServiceListBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.ServiceListBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/support/ticket-details/src/sdk/ticket-details.ts
+++ b/packages/blocks/support/ticket-details/src/sdk/ticket-details.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/ticket-details.client';
 import { URL } from '../api-harmonization/ticket-details.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/ticket-details.url';
 const API_URL = URL;
 
 export const ticketDetails = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/support/ticket-details/src/sdk/ticket-details.ts
+++ b/packages/blocks/support/ticket-details/src/sdk/ticket-details.ts
@@ -1,34 +1,28 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/ticket-details.client';
 import { URL } from '../api-harmonization/ticket-details.url';
 
 const API_URL = URL;
 
-export const ticketDetails = (sdk: Sdk) => ({
-    blocks: {
-        getTicketDetails: (
-            params: Request.GetTicketDetailsBlockParams,
-            query: Request.GetTicketDetailsBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.TicketDetailsBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}/${params.id}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const ticketDetails = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getTicketDetails: (
+                params: Request.GetTicketDetailsBlockParams,
+                query: Request.GetTicketDetailsBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.TicketDetailsBlock> =>
+                request({
+                    url: `${API_URL}/${params.id}`,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/support/ticket-list/src/sdk/ticket-list.ts
+++ b/packages/blocks/support/ticket-list/src/sdk/ticket-list.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/ticket-list.client';
 import { URL } from '../api-harmonization/ticket-list.url';
 
 const API_URL = URL;
 
-export const ticketList = (sdk: Sdk) => ({
-    blocks: {
-        getTicketList: (
-            query: Request.GetTicketListBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.TicketListBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const ticketList = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getTicketList: (
+                query: Request.GetTicketListBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.TicketListBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/support/ticket-list/src/sdk/ticket-list.ts
+++ b/packages/blocks/support/ticket-list/src/sdk/ticket-list.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/ticket-list.client';
 import { URL } from '../api-harmonization/ticket-list.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/ticket-list.url';
 const API_URL = URL;
 
 export const ticketList = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/support/ticket-recent/src/sdk/ticket-recent.ts
+++ b/packages/blocks/support/ticket-recent/src/sdk/ticket-recent.ts
@@ -1,33 +1,27 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/ticket-recent.client';
 import { URL } from '../api-harmonization/ticket-recent.url';
 
 const API_URL = URL;
 
-export const ticketRecent = (sdk: Sdk) => ({
-    blocks: {
-        getTicketRecent: (
-            query: Request.GetTicketRecentBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.TicketRecentBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const ticketRecent = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getTicketRecent: (
+                query: Request.GetTicketRecentBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.TicketRecentBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/support/ticket-recent/src/sdk/ticket-recent.ts
+++ b/packages/blocks/support/ticket-recent/src/sdk/ticket-recent.ts
@@ -1,5 +1,5 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request } from '../api-harmonization/ticket-recent.client';
 import { URL } from '../api-harmonization/ticket-recent.url';
@@ -7,7 +7,7 @@ import { URL } from '../api-harmonization/ticket-recent.url';
 const API_URL = URL;
 
 export const ticketRecent = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/blocks/support/ticket-summary/src/sdk/ticket-summary.ts
+++ b/packages/blocks/support/ticket-summary/src/sdk/ticket-summary.ts
@@ -1,32 +1,26 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/ticket-summary.client';
 
 const API_URL = URL;
 
-export const ticketSummary = (sdk: Sdk) => ({
-    blocks: {
-        getTicketSummary: (
-            query: Request.GetTicketSummaryBlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.TicketSummaryBlock> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const ticketSummary = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            getTicketSummary: (
+                query: Request.GetTicketSummaryBlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.TicketSummaryBlock> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/packages/blocks/support/ticket-summary/src/sdk/ticket-summary.ts
+++ b/packages/blocks/support/ticket-summary/src/sdk/ticket-summary.ts
@@ -1,12 +1,12 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/ticket-summary.client';
 
 const API_URL = URL;
 
 export const ticketSummary = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {

--- a/packages/framework/src/headers.ts
+++ b/packages/framework/src/headers.ts
@@ -1,1 +1,2 @@
 export * from './utils/models/headers';
+export * from './utils/api-headers';

--- a/packages/framework/src/sdk.spec.ts
+++ b/packages/framework/src/sdk.spec.ts
@@ -1,0 +1,34 @@
+import type { FetchOptions } from 'ofetch';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getSdk } from './sdk';
+
+const ofetchInstance = vi.fn(async (_url: string, _options?: FetchOptions) => ({}));
+
+vi.mock('ofetch', () => ({
+    ofetch: { create: () => ofetchInstance },
+}));
+
+const lastOptions = () => ofetchInstance.mock.calls[ofetchInstance.mock.calls.length - 1]![1];
+
+describe('makeRequest', () => {
+    beforeEach(() => {
+        ofetchInstance.mockClear();
+    });
+
+    it('should forward the response type, so that it is not guessed from the content type', async () => {
+        const sdk = getSdk({ apiUrl: 'https://api.example.com' });
+
+        await sdk.makeRequest({ url: '/invoices/1/pdf', responseType: 'blob' });
+
+        expect(lastOptions()).toMatchObject({ responseType: 'blob' });
+    });
+
+    it('should leave the response type to ofetch when the caller does not ask for one', async () => {
+        const sdk = getSdk({ apiUrl: 'https://api.example.com' });
+
+        await sdk.makeRequest({ url: '/invoices' });
+
+        expect(lastOptions()).not.toHaveProperty('responseType');
+    });
+});

--- a/packages/framework/src/sdk.ts
+++ b/packages/framework/src/sdk.ts
@@ -8,6 +8,15 @@ import { createInterceptors } from './interceptors';
 import { LoggerConfig } from './utils/logger';
 import { AppHeaders } from './utils/models/headers';
 
+export { BlockRequestError, createBlockMethod } from './utils/block-method';
+export type {
+    BlockRequest,
+    BlockRequestConfig,
+    BlockRequestHeaders,
+    BlockRequestMethod,
+    BlockResponseType,
+} from './utils/block-method';
+
 export interface CompatRequestConfig {
     url?: string;
     method?: string;

--- a/packages/framework/src/sdk.ts
+++ b/packages/framework/src/sdk.ts
@@ -5,6 +5,7 @@ import { getNotification, getNotifications, markAs } from './api/notifications';
 import { createTicket, getTicket, getTickets } from './api/tickets';
 import { getCustomerForCurrentUserById, getDefaultCustomerForCurrentUser, getUser } from './api/users';
 import { createInterceptors } from './interceptors';
+import type { BlockResponseType } from './utils/block-method';
 import { LoggerConfig } from './utils/logger';
 import { AppHeaders } from './utils/models/headers';
 
@@ -23,6 +24,7 @@ export interface CompatRequestConfig {
     headers?: Partial<AppHeaders> & Record<string, string>;
     params?: unknown;
     data?: unknown;
+    responseType?: BlockResponseType;
     [key: string]: unknown;
 }
 
@@ -95,6 +97,10 @@ export const getSdk = ({ apiUrl, logger }: SdkConfig): Sdk => {
 
         if (config.headers) {
             fetchOptions.headers = config.headers as FetchOptions['headers'];
+        }
+
+        if (config.responseType) {
+            fetchOptions.responseType = config.responseType;
         }
 
         const url = config.url || '';

--- a/packages/framework/src/sdk.ts
+++ b/packages/framework/src/sdk.ts
@@ -5,18 +5,18 @@ import { getNotification, getNotifications, markAs } from './api/notifications';
 import { createTicket, getTicket, getTickets } from './api/tickets';
 import { getCustomerForCurrentUserById, getDefaultCustomerForCurrentUser, getUser } from './api/users';
 import { createInterceptors } from './interceptors';
-import type { BlockResponseType } from './utils/block-method';
+import type { BlockResponseType } from './utils/block-request';
 import { LoggerConfig } from './utils/logger';
 import { AppHeaders } from './utils/models/headers';
 
-export { BlockRequestError, createBlockMethod } from './utils/block-method';
+export { BlockRequestError, createBlockRequest } from './utils/block-request';
 export type {
     BlockRequest,
     BlockRequestConfig,
     BlockRequestHeaders,
     BlockRequestMethod,
     BlockResponseType,
-} from './utils/block-method';
+} from './utils/block-request';
 
 export interface CompatRequestConfig {
     url?: string;

--- a/packages/framework/src/utils/api-headers.spec.ts
+++ b/packages/framework/src/utils/api-headers.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { getApiHeaders } from './api-headers';
+import { HeaderName } from './models/headers';
+
+describe('getApiHeaders', () => {
+    it('should send the time zone of the client', () => {
+        expect(getApiHeaders()).toEqual({
+            [HeaderName.ClientTimezone]: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        });
+    });
+
+    it('should return a new object every time, as callers add their own headers to it', () => {
+        const headers = getApiHeaders();
+        headers[HeaderName.Locale] = 'en';
+
+        expect(getApiHeaders()).not.toHaveProperty(HeaderName.Locale);
+    });
+});

--- a/packages/framework/src/utils/api-headers.ts
+++ b/packages/framework/src/utils/api-headers.ts
@@ -1,0 +1,10 @@
+import { HeaderName } from './models/headers';
+
+/**
+ * Default headers sent with every request made to the API Harmonization Server.
+ */
+export const getApiHeaders = (): Record<string, string> => {
+    return {
+        [HeaderName.ClientTimezone]: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    };
+};

--- a/packages/framework/src/utils/api-headers.ts
+++ b/packages/framework/src/utils/api-headers.ts
@@ -1,10 +1,19 @@
 import { HeaderName } from './models/headers';
 
 /**
+ * Resolving the time zone constructs an `Intl.DateTimeFormat`, which costs orders of magnitude more than
+ * everything else the request setup does, and neither a process nor a browser tab changes its time zone.
+ * This is the IANA name (`Europe/Warsaw`), so it does not follow DST either.
+ */
+let clientTimezone: string | undefined;
+
+/**
  * Default headers sent with every request made to the API Harmonization Server.
  */
 export const getApiHeaders = (): Record<string, string> => {
+    clientTimezone ??= Intl.DateTimeFormat().resolvedOptions().timeZone;
+
     return {
-        [HeaderName.ClientTimezone]: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        [HeaderName.ClientTimezone]: clientTimezone,
     };
 };

--- a/packages/framework/src/utils/block-method.spec.ts
+++ b/packages/framework/src/utils/block-method.spec.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { CompatRequestConfig, Sdk } from '../sdk';
 
-import { createBlockMethod } from './block-method';
+import { type BlockRequestConfig, BlockRequestError, createBlockMethod } from './block-method';
+import { HeaderName } from './models/headers';
+
+const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 const createSdk = () => {
     const makeRequest = vi.fn(async (_config: CompatRequestConfig) => ({}));
@@ -14,43 +17,113 @@ const createSdk = () => {
 const lastConfig = (makeRequest: ReturnType<typeof createSdk>['makeRequest']): CompatRequestConfig =>
     makeRequest.mock.calls[makeRequest.mock.calls.length - 1]![0];
 
+const sendRequest = async (config: BlockRequestConfig) => {
+    const { sdk, makeRequest } = createSdk();
+
+    await createBlockMethod(sdk)(config);
+
+    return lastConfig(makeRequest);
+};
+
+const failWith = async (error: unknown, config: BlockRequestConfig = { url: '/tickets' }) => {
+    const { sdk, makeRequest } = createSdk();
+    makeRequest.mockRejectedValueOnce(error);
+
+    return createBlockMethod(sdk)<never>(config).catch((caught: unknown) => caught as BlockRequestError);
+};
+
 describe('createBlockMethod', () => {
+    describe('headers', () => {
+        it('should send the default API headers', async () => {
+            const config = await sendRequest({ url: '/tickets' });
+
+            expect(config.headers).toEqual({ [HeaderName.ClientTimezone]: TIMEZONE });
+        });
+
+        it('should merge the headers of the caller on top of the default ones', async () => {
+            const config = await sendRequest({
+                url: '/tickets',
+                headers: { [HeaderName.Locale]: 'en', [HeaderName.ClientTimezone]: 'Europe/Warsaw' },
+            });
+
+            expect(config.headers).toEqual({
+                [HeaderName.Locale]: 'en',
+                [HeaderName.ClientTimezone]: 'Europe/Warsaw',
+            });
+        });
+
+        it('should keep a default header the caller passed as undefined', async () => {
+            const config = await sendRequest({
+                url: '/tickets',
+                headers: { [HeaderName.ClientTimezone]: undefined },
+            });
+
+            expect(config.headers).toEqual({ [HeaderName.ClientTimezone]: TIMEZONE });
+        });
+
+        it('should match the header names of the caller case-insensitively', async () => {
+            const config = await sendRequest({
+                url: '/tickets',
+                headers: { 'X-Locale': 'en', 'X-Client-Timezone': 'Europe/Warsaw' },
+            });
+
+            expect(config.headers).toEqual({
+                [HeaderName.Locale]: 'en',
+                [HeaderName.ClientTimezone]: 'Europe/Warsaw',
+            });
+        });
+
+        it('should send the access token as a bearer authorization header', async () => {
+            const config = await sendRequest({ url: '/tickets', authorization: 'token' });
+
+            expect(config.headers).toMatchObject({ [HeaderName.Authorization]: 'Bearer token' });
+        });
+
+        it('should let the access token win over an authorization header of the caller', async () => {
+            const config = await sendRequest({
+                url: '/tickets',
+                headers: { Authorization: 'Bearer stale' },
+                authorization: 'token',
+            });
+
+            expect(config.headers).toMatchObject({ [HeaderName.Authorization]: 'Bearer token' });
+        });
+
+        it('should keep the authorization header of the caller when there is no access token', async () => {
+            const config = await sendRequest({ url: '/tickets', headers: { Authorization: 'Basic dXNlcg==' } });
+
+            expect(config.headers).toMatchObject({ [HeaderName.Authorization]: 'Basic dXNlcg==' });
+        });
+    });
+
     describe('supported params', () => {
         it('should send an object of query params, without the undefined ones', async () => {
-            const { sdk, makeRequest } = createSdk();
+            const config = await sendRequest({ url: '/tickets', params: { limit: 10, search: undefined } });
 
-            await createBlockMethod(sdk)({ url: '/tickets', params: { limit: 10, search: undefined } });
-
-            expect(lastConfig(makeRequest).params).toEqual({ limit: 10 });
+            expect(config.params).toEqual({ limit: 10 });
         });
 
         it('should send the params of a query class instance', async () => {
-            const { sdk, makeRequest } = createSdk();
-
             class GetTicketListQuery {
                 id = 'ticket-list';
                 limit?: number = 10;
             }
 
-            await createBlockMethod(sdk)({ url: '/tickets', params: new GetTicketListQuery() });
+            const config = await sendRequest({ url: '/tickets', params: new GetTicketListQuery() });
 
-            expect(lastConfig(makeRequest).params).toEqual({ id: 'ticket-list', limit: 10 });
+            expect(config.params).toEqual({ id: 'ticket-list', limit: 10 });
         });
 
         it('should send an empty query when there are no params to send', async () => {
-            const { sdk, makeRequest } = createSdk();
+            const config = await sendRequest({ url: '/tickets', params: {} });
 
-            await createBlockMethod(sdk)({ url: '/tickets', params: {} });
-
-            expect(lastConfig(makeRequest).params).toEqual({});
+            expect(config.params).toEqual({});
         });
 
         it('should not send a query at all when params are not provided', async () => {
-            const { sdk, makeRequest } = createSdk();
+            const config = await sendRequest({ url: '/tickets' });
 
-            await createBlockMethod(sdk)({ url: '/tickets' });
-
-            expect(lastConfig(makeRequest)).not.toHaveProperty('params');
+            expect(config).not.toHaveProperty('params');
         });
     });
 
@@ -67,6 +140,62 @@ describe('createBlockMethod', () => {
                 new TypeError(`Query params have to be an object of key/value pairs, received [object ${tag}].`),
             );
             expect(makeRequest).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('errors', () => {
+        it('should take the status of an error that carries it directly', async () => {
+            const error = await failWith({ status: 404, message: 'Not Found' });
+
+            expect(error).toBeInstanceOf(BlockRequestError);
+            expect(error.status).toBe(404);
+            expect(error.message).toBe('[GET /tickets] 404 Not Found');
+        });
+
+        it('should take the status of an error that calls it statusCode', async () => {
+            const error = await failWith({ statusCode: 500, message: 'Server Error' });
+
+            expect(error.status).toBe(500);
+            expect(error.message).toBe('[GET /tickets] 500 Server Error');
+        });
+
+        it('should take the status out of the response of an error', async () => {
+            const error = await failWith({ message: 'Bad Request', response: { status: 400, data: { code: 'x' } } });
+
+            expect(error.status).toBe(400);
+            expect(error.data).toEqual({ code: 'x' });
+            expect(error.response).toEqual({ status: 400, data: { code: 'x' } });
+        });
+
+        it('should prefer the data of the error itself over the one of its response', async () => {
+            const error = await failWith({ data: 'own', response: { status: 400, data: 'response' } });
+
+            expect(error.data).toBe('own');
+        });
+
+        it('should describe an error that carries neither a status nor a message', async () => {
+            const error = await failWith('boom', { url: '/tickets', method: 'delete' });
+
+            expect(error.status).toBeUndefined();
+            expect(error.message).toBe('[DELETE /tickets] Request failed');
+            expect(error.method).toBe('delete');
+            expect(error.url).toBe('/tickets');
+        });
+
+        it('should keep the original error as the cause', async () => {
+            const cause = { status: 404, message: 'Not Found' };
+
+            expect((await failWith(cause)).cause).toBe(cause);
+        });
+
+        it('should not wrap an error that is already a BlockRequestError', async () => {
+            const original = new BlockRequestError('[GET /tickets] 404 Not Found', {
+                method: 'get',
+                url: '/tickets',
+                status: 404,
+            });
+
+            expect(await failWith(original)).toBe(original);
         });
     });
 });

--- a/packages/framework/src/utils/block-method.spec.ts
+++ b/packages/framework/src/utils/block-method.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CompatRequestConfig, Sdk } from '../sdk';
+
+import { createBlockMethod } from './block-method';
+
+const createSdk = () => {
+    const makeRequest = vi.fn(async (_config: CompatRequestConfig) => ({}));
+    const sdk = { makeRequest } as unknown as Pick<Sdk, 'makeRequest'>;
+
+    return { sdk, makeRequest };
+};
+
+const lastConfig = (makeRequest: ReturnType<typeof createSdk>['makeRequest']): CompatRequestConfig =>
+    makeRequest.mock.calls[makeRequest.mock.calls.length - 1]![0];
+
+describe('createBlockMethod', () => {
+    describe('supported params', () => {
+        it('should send an object of query params, without the undefined ones', async () => {
+            const { sdk, makeRequest } = createSdk();
+
+            await createBlockMethod(sdk)({ url: '/tickets', params: { limit: 10, search: undefined } });
+
+            expect(lastConfig(makeRequest).params).toEqual({ limit: 10 });
+        });
+
+        it('should send the params of a query class instance', async () => {
+            const { sdk, makeRequest } = createSdk();
+
+            class GetTicketListQuery {
+                id = 'ticket-list';
+                limit?: number = 10;
+            }
+
+            await createBlockMethod(sdk)({ url: '/tickets', params: new GetTicketListQuery() });
+
+            expect(lastConfig(makeRequest).params).toEqual({ id: 'ticket-list', limit: 10 });
+        });
+
+        it('should send an empty query when there are no params to send', async () => {
+            const { sdk, makeRequest } = createSdk();
+
+            await createBlockMethod(sdk)({ url: '/tickets', params: {} });
+
+            expect(lastConfig(makeRequest).params).toEqual({});
+        });
+
+        it('should not send a query at all when params are not provided', async () => {
+            const { sdk, makeRequest } = createSdk();
+
+            await createBlockMethod(sdk)({ url: '/tickets' });
+
+            expect(lastConfig(makeRequest)).not.toHaveProperty('params');
+        });
+    });
+
+    describe('unsupported params', () => {
+        it.each([
+            ['Date', new Date()],
+            ['Map', new Map([['limit', 10]])],
+            ['Set', new Set(['limit'])],
+            ['URLSearchParams', new URLSearchParams({ limit: '10' })],
+        ])('should reject a %s instead of sending an empty query', async (tag, params) => {
+            const { sdk, makeRequest } = createSdk();
+
+            await expect(createBlockMethod(sdk)({ url: '/tickets', params })).rejects.toThrow(
+                new TypeError(`Query params have to be an object of key/value pairs, received [object ${tag}].`),
+            );
+            expect(makeRequest).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/framework/src/utils/block-method.ts
+++ b/packages/framework/src/utils/block-method.ts
@@ -14,7 +14,11 @@ export interface BlockRequestConfig {
     url: string;
     /** HTTP method, `get` by default. */
     method?: BlockRequestMethod;
-    /** Query params - serialized into the query string, with `undefined` values dropped. */
+    /**
+     * Query params - an object of key/value pairs, serialized into the query string, with `undefined`
+     * values dropped. Built-ins that keep their content out of own properties (`Date`, `Map`, `Set`,
+     * `URLSearchParams`, ...) are rejected, as they would silently serialize into an empty query.
+     */
     params?: unknown;
     /** Request body. */
     data?: unknown;
@@ -89,6 +93,8 @@ const mergeHeaders = (headers?: BlockRequestHeaders, authorization?: string): Re
     return merged;
 };
 
+const QUERY_OBJECT_TAG = '[object Object]';
+
 const serializeParams = (params: unknown): unknown => {
     if (params === undefined || params === null) {
         return undefined;
@@ -96,6 +102,12 @@ const serializeParams = (params: unknown): unknown => {
 
     if (typeof params !== 'object' || Array.isArray(params)) {
         return params;
+    }
+
+    const tag = Object.prototype.toString.call(params);
+
+    if (tag !== QUERY_OBJECT_TAG) {
+        throw new TypeError(`Query params have to be an object of key/value pairs, received ${tag}.`);
     }
 
     return Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined));

--- a/packages/framework/src/utils/block-method.ts
+++ b/packages/framework/src/utils/block-method.ts
@@ -1,0 +1,192 @@
+import type { CompatRequestConfig, Sdk } from '../sdk';
+
+import { getApiHeaders } from './api-headers';
+import { AppHeaders, HeaderName } from './models/headers';
+
+export type BlockRequestMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
+
+export type BlockRequestHeaders = Partial<AppHeaders> | Record<string, string | undefined>;
+
+export type BlockResponseType = 'json' | 'text' | 'blob' | 'arrayBuffer' | 'stream';
+
+export interface BlockRequestConfig {
+    /** Path of the endpoint, relative to the API Harmonization Server URL. */
+    url: string;
+    /** HTTP method, `get` by default. */
+    method?: BlockRequestMethod;
+    /** Query params - serialized into the query string, with `undefined` values dropped. */
+    params?: unknown;
+    /** Request body. */
+    data?: unknown;
+    /** Headers provided by the caller, merged on top of the default API headers. */
+    headers?: BlockRequestHeaders;
+    /** Access token, sent as the `authorization` header when provided. */
+    authorization?: string;
+    /** Expected response type, `json` by default. */
+    responseType?: BlockResponseType;
+}
+
+/**
+ * Performs a single request to the API Harmonization Server, with the response typed as `TResponse`.
+ */
+export type BlockRequest = <TResponse>(config: BlockRequestConfig) => Promise<TResponse>;
+
+interface BlockRequestErrorOptions {
+    method: BlockRequestMethod;
+    url: string;
+    status?: number;
+    data?: unknown;
+    response?: BlockErrorResponse;
+    cause?: unknown;
+}
+
+interface BlockErrorResponse {
+    status?: number;
+    data?: unknown;
+}
+
+/**
+ * Error thrown by every method created with {@link createBlockMethod}. It normalizes the various error
+ * shapes returned by the underlying fetch client and keeps the original error available as `cause`.
+ */
+export class BlockRequestError extends Error {
+    /** HTTP method of the failed request. */
+    readonly method: BlockRequestMethod;
+    /** URL of the failed request. */
+    readonly url: string;
+    /** HTTP status code, when the request reached the server. */
+    readonly status?: number;
+    /** Response payload returned by the server. */
+    readonly data?: unknown;
+    /** Raw response details, as returned by the underlying fetch client. */
+    readonly response?: BlockErrorResponse;
+
+    constructor(message: string, options: BlockRequestErrorOptions) {
+        super(message, { cause: options.cause });
+
+        this.name = 'BlockRequestError';
+        this.method = options.method;
+        this.url = options.url;
+        this.status = options.status;
+        this.data = options.data;
+        this.response = options.response;
+    }
+}
+
+const mergeHeaders = (headers?: BlockRequestHeaders, authorization?: string): Record<string, string> => {
+    const merged: Record<string, string> = getApiHeaders();
+
+    for (const [name, value] of Object.entries(headers || {})) {
+        if (value !== undefined) {
+            merged[name] = value;
+        }
+    }
+
+    if (authorization) {
+        merged[HeaderName.Authorization] = `Bearer ${authorization}`;
+    }
+
+    return merged;
+};
+
+const serializeParams = (params: unknown): unknown => {
+    if (params === undefined || params === null) {
+        return undefined;
+    }
+
+    if (typeof params !== 'object' || Array.isArray(params)) {
+        return params;
+    }
+
+    return Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined));
+};
+
+const toStatus = (value: unknown): number | undefined => {
+    return typeof value === 'number' ? value : undefined;
+};
+
+const toBlockRequestError = (error: unknown, method: BlockRequestMethod, url: string): BlockRequestError => {
+    if (error instanceof BlockRequestError) {
+        return error;
+    }
+
+    const source = (typeof error === 'object' && error !== null ? error : {}) as {
+        message?: unknown;
+        status?: unknown;
+        statusCode?: unknown;
+        data?: unknown;
+        response?: BlockErrorResponse;
+    };
+
+    const status = toStatus(source.status) ?? toStatus(source.statusCode) ?? toStatus(source.response?.status);
+    const message = typeof source.message === 'string' && source.message ? source.message : 'Request failed';
+
+    return new BlockRequestError(`[${method.toUpperCase()} ${url}]${status ? ` ${status}` : ''} ${message}`, {
+        method,
+        url,
+        status,
+        data: source.data ?? source.response?.data,
+        response: source.response,
+        cause: error,
+    });
+};
+
+/**
+ * Creates the request function used by the methods of a block (or module) SDK. It takes care of
+ * merging the default API headers with the ones provided by the caller and with the access token,
+ * serializing query params, typing the response and wrapping errors into {@link BlockRequestError}.
+ *
+ * @example
+ * ```typescript
+ * export const ticketList = (sdk: Sdk) => {
+ *     const request = createBlockMethod(sdk);
+ *
+ *     return {
+ *         blocks: {
+ *             getTicketList: (
+ *                 query: Request.GetTicketListBlockQuery,
+ *                 headers: AppHeaders,
+ *                 authorization?: string,
+ *             ): Promise<Model.TicketListBlock> =>
+ *                 request({
+ *                     url: API_URL,
+ *                     params: query,
+ *                     headers,
+ *                     authorization,
+ *                 }),
+ *         },
+ *     };
+ * };
+ * ```
+ */
+export const createBlockMethod = (sdk: Pick<Sdk, 'makeRequest'>): BlockRequest => {
+    return async <TResponse>(config: BlockRequestConfig): Promise<TResponse> => {
+        const { url, method = 'get', params, data, headers, authorization, responseType } = config;
+
+        const requestConfig: CompatRequestConfig = {
+            method,
+            url,
+            headers: mergeHeaders(headers, authorization),
+        };
+
+        const query = serializeParams(params);
+
+        if (query !== undefined) {
+            requestConfig.params = query;
+        }
+
+        if (data !== undefined) {
+            requestConfig.data = data;
+        }
+
+        if (responseType !== undefined) {
+            requestConfig.responseType = responseType;
+        }
+
+        try {
+            return await sdk.makeRequest<TResponse>(requestConfig);
+        } catch (error) {
+            throw toBlockRequestError(error, method, url);
+        }
+    };
+};

--- a/packages/framework/src/utils/block-method.ts
+++ b/packages/framework/src/utils/block-method.ts
@@ -78,7 +78,7 @@ const mergeHeaders = (headers?: BlockRequestHeaders, authorization?: string): Re
 
     for (const [name, value] of Object.entries(headers || {})) {
         if (value !== undefined) {
-            merged[name] = value;
+            merged[name.toLowerCase()] = value;
         }
     }
 

--- a/packages/framework/src/utils/block-request.spec.ts
+++ b/packages/framework/src/utils/block-request.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { CompatRequestConfig, Sdk } from '../sdk';
 
-import { type BlockRequestConfig, BlockRequestError, createBlockMethod } from './block-method';
+import { type BlockRequestConfig, BlockRequestError, createBlockRequest } from './block-request';
 import { HeaderName } from './models/headers';
 
 const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -20,7 +20,7 @@ const lastConfig = (makeRequest: ReturnType<typeof createSdk>['makeRequest']): C
 const sendRequest = async (config: BlockRequestConfig) => {
     const { sdk, makeRequest } = createSdk();
 
-    await createBlockMethod(sdk)(config);
+    await createBlockRequest(sdk)(config);
 
     return lastConfig(makeRequest);
 };
@@ -29,10 +29,10 @@ const failWith = async (error: unknown, config: BlockRequestConfig = { url: '/ti
     const { sdk, makeRequest } = createSdk();
     makeRequest.mockRejectedValueOnce(error);
 
-    return createBlockMethod(sdk)<never>(config).catch((caught: unknown) => caught as BlockRequestError);
+    return createBlockRequest(sdk)<never>(config).catch((caught: unknown) => caught as BlockRequestError);
 };
 
-describe('createBlockMethod', () => {
+describe('createBlockRequest', () => {
     describe('headers', () => {
         it('should send the default API headers', async () => {
             const config = await sendRequest({ url: '/tickets' });
@@ -136,7 +136,7 @@ describe('createBlockMethod', () => {
         ])('should reject a %s instead of sending an empty query', async (tag, params) => {
             const { sdk, makeRequest } = createSdk();
 
-            await expect(createBlockMethod(sdk)({ url: '/tickets', params })).rejects.toThrow(
+            await expect(createBlockRequest(sdk)({ url: '/tickets', params })).rejects.toThrow(
                 new TypeError(`Query params have to be an object of key/value pairs, received [object ${tag}].`),
             );
             expect(makeRequest).not.toHaveBeenCalled();

--- a/packages/framework/src/utils/block-request.ts
+++ b/packages/framework/src/utils/block-request.ts
@@ -50,7 +50,7 @@ interface BlockErrorResponse {
 }
 
 /**
- * Error thrown by every method created with {@link createBlockMethod}. It normalizes the various error
+ * Error thrown by every method created with {@link createBlockRequest}. It normalizes the various error
  * shapes returned by the underlying fetch client and keeps the original error available as `cause`.
  */
 export class BlockRequestError extends Error {
@@ -151,7 +151,7 @@ const toBlockRequestError = (error: unknown, method: BlockRequestMethod, url: st
  * @example
  * ```typescript
  * export const ticketList = (sdk: Sdk) => {
- *     const request = createBlockMethod(sdk);
+ *     const request = createBlockRequest(sdk);
  *
  *     return {
  *         blocks: {
@@ -171,7 +171,7 @@ const toBlockRequestError = (error: unknown, method: BlockRequestMethod, url: st
  * };
  * ```
  */
-export const createBlockMethod = (sdk: Pick<Sdk, 'makeRequest'>): BlockRequest => {
+export const createBlockRequest = (sdk: Pick<Sdk, 'makeRequest'>): BlockRequest => {
     return async <TResponse>(config: BlockRequestConfig): Promise<TResponse> => {
         const { url, method = 'get', params, data, headers, authorization, responseType } = config;
 

--- a/packages/modules/surveyjs/src/sdk/surveyjs.ts
+++ b/packages/modules/surveyjs/src/sdk/surveyjs.ts
@@ -1,12 +1,12 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/surveyjs.client';
 
 const API_URL = URL;
 
 export const surveyjs = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         modules: {

--- a/packages/modules/surveyjs/src/sdk/surveyjs.ts
+++ b/packages/modules/surveyjs/src/sdk/surveyjs.ts
@@ -1,49 +1,40 @@
-import { Utils } from '@o2s/utils.frontend';
-
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk } from '@o2s/framework/sdk';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/surveyjs.client';
 
 const API_URL = URL;
 
-export const surveyjs = (sdk: Sdk) => ({
-    modules: {
-        getSurvey: (
-            params: Request.SurveyJsQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.SurveyJs> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: API_URL,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              Authorization: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: params,
-            }),
+export const surveyjs = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
 
-        submitSurvey: (
-            params: Request.SurveyJsSubmitPayload,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<void> => {
-            return sdk.makeRequest({
-                method: 'post',
-                url: API_URL,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
-                },
-                data: params,
-            });
+    return {
+        modules: {
+            getSurvey: (
+                params: Request.SurveyJsQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.SurveyJs> =>
+                request({
+                    url: API_URL,
+                    params: params,
+                    headers,
+                    authorization,
+                }),
+
+            submitSurvey: (
+                params: Request.SurveyJsSubmitPayload,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<void> => {
+                return request({
+                    method: 'post',
+                    url: API_URL,
+                    data: params,
+                    headers,
+                    authorization,
+                });
+            },
         },
-    },
-});
+    };
+};

--- a/packages/utils/frontend/src/utils/headers.ts
+++ b/packages/utils/frontend/src/utils/headers.ts
@@ -1,5 +1,1 @@
-export const getApiHeaders = () => {
-    return {
-        'x-client-timezone': Intl.DateTimeFormat().resolvedOptions().timeZone,
-    };
-};
+export { getApiHeaders } from '@o2s/framework/headers';

--- a/turbo/generators/templates/block/sdk/block.hbs
+++ b/turbo/generators/templates/block/sdk/block.hbs
@@ -1,33 +1,26 @@
-import { Utils } from '@o2s/utils.frontend';
-
-import { Sdk } from '@o2s/framework/sdk';
+import { AppHeaders } from '@o2s/framework/headers';
+import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/{{kebabCase name}}.client';
-import { AppHeaders, HeaderName } from '@o2s/framework/headers';
 
 const API_URL = URL;
-const H = HeaderName;
 
-export const {{ camelCase name }} = (sdk: Sdk) => ({
-    blocks: {
-        get{{ pascalCase name }}: (
-            query: Request.Get{{ pascalCase name }}BlockQuery,
-            headers: AppHeaders,
-            authorization?: string,
-        ): Promise<Model.{{ pascalCase name }}Block> =>
-            sdk.makeRequest({
-                method: 'get',
-                url: `${API_URL}`,
-                headers: {
-                    ...Utils.Headers.getApiHeaders(),
-                    ...headers,
-                    ...(authorization
-                        ? {
-                              [H.Authorization]: `Bearer ${authorization}`,
-                          }
-                        : {}),
-                },
-                params: query,
-            }),
-    },
-});
+export const {{ camelCase name }} = (sdk: Sdk) => {
+    const request = createBlockMethod(sdk);
+
+    return {
+        blocks: {
+            get{{ pascalCase name }}: (
+                query: Request.Get{{ pascalCase name }}BlockQuery,
+                headers: AppHeaders,
+                authorization?: string,
+            ): Promise<Model.{{ pascalCase name }}Block> =>
+                request({
+                    url: API_URL,
+                    params: query,
+                    headers,
+                    authorization,
+                }),
+        },
+    };
+};

--- a/turbo/generators/templates/block/sdk/block.hbs
+++ b/turbo/generators/templates/block/sdk/block.hbs
@@ -1,12 +1,12 @@
 import { AppHeaders } from '@o2s/framework/headers';
-import { Sdk, createBlockMethod } from '@o2s/framework/sdk';
+import { Sdk, createBlockRequest } from '@o2s/framework/sdk';
 
 import { Model, Request, URL } from '../api-harmonization/{{kebabCase name}}.client';
 
 const API_URL = URL;
 
 export const {{ camelCase name }} = (sdk: Sdk) => {
-    const request = createBlockMethod(sdk);
+    const request = createBlockRequest(sdk);
 
     return {
         blocks: {


### PR DESCRIPTION
**What does this PR do?**

- [x] My feature

**Related Ticket(s)**

- Closes #770

**Key Changes**

- Adds `createBlockMethod` to `@o2s/framework/sdk` (`packages/framework/src/utils/block-method.ts`). It creates the request function used by the methods of a block (or module) SDK and handles the boilerplate previously copy-pasted into every method:
    - **header merging** — default API headers + caller headers + `authorization` (`undefined` values filtered out, the token is only sent when provided),
    - **params serialization** — `undefined` entries dropped, no `params` key at all when there is no query,
    - **response typing** — via the `TResponse` generic,
    - **error wrapping** — every failure becomes a `BlockRequestError` exposing `status`, `data` and `response`, with the original error kept as `cause` and the method + URL in the message (`[GET /carts/1] 404 Not Found`).
- Moves `getApiHeaders` to `@o2s/framework/headers`, so the default headers live in one place. `Utils.Headers.getApiHeaders` from `@o2s/utils.frontend` re-exports it (no breaking change), and the duplicated `apps/frontend/src/utils/api.ts` is removed.
- Refactors all 42 block SDKs, the SurveyJS module SDK, the 5 frontend app module SDKs and the block generator template (`turbo/generators/templates/block/sdk/block.hbs`) to use the helper — every method loses its 8-line header block (net −386 lines of block/module SDK code).
- The factory shape (`(sdk: Sdk) => ({ blocks: … })`) is intentionally kept, since each block's `sdk/index.ts` and external consumers depend on it — only the method internals changed.
- Documents the pattern in `apps/docs/docs/main-components/blocks/structure.md` and adds a changeset (`@o2s/framework` minor, the rest patch).

Three deliberate behavior changes:

- the token is sent as `authorization` (the `HeaderName.Authorization` constant, as in the generator template) instead of `Authorization` — the server reads `headers[H.Authorization]` anyway, and the token no longer collides with an `authorization` key coming from `AppHeaders`,
- `getOrderPdf` no longer sends `Bearer undefined` when no token is passed,
- errors are now `BlockRequestError` instances — both `err.status` and `err.response?.status` (used in `CheckoutSummary.client.tsx`) keep working.

**How to test**

No migrations or extra setup needed.

1. `npm run build` — 62/62 tasks pass.
2. `npm run lint` — 52/52 tasks pass.
3. `npm run test` — 45/45 tasks pass.
4. Run the app and open pages backed by the refactored blocks (ticket list, invoice list with PDF download, product details, cart/checkout) — requests should carry `x-locale`, `x-client-timezone` and the bearer token, and failures should be logged as `BlockRequestError` with the status.

Additionally verified against a local HTTP server through the real `getSdk`: correct URL and query (`?id=block-1`, with `preview: undefined` dropped), `authorization: Bearer …`, both custom headers present, and a 404 wrapped into `BlockRequestError` with `status` and `data` preserved.

**Media (Loom or gif)**

- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared request helper for SDK-powered blocks and modules.
  * Added consistent query serialization, header and authorization handling, response typing, and support for multiple response formats.
  * Added standardized request errors with method, URL, status, response data, and original cause details.
  * Safely encoded cart, invoice, and checkout identifiers in request URLs.
  * Updated SDK documentation and generation templates.

* **Bug Fixes**
  * Improved timezone header reuse and request error consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->