### PR TITLE
feat: reduce block registration to a single config per app (#769)

### DIFF
--- a/apps/api-harmonization/src/app.module.ts
+++ b/apps/api-harmonization/src/app.module.ts
@@ -29,52 +29,9 @@ import {
     createModule,
 } from '@o2s/framework/modules';
 
-import * as ArticleList from '@o2s/blocks.article-list/api-harmonization';
-import * as ArticleSearch from '@o2s/blocks.article-search/api-harmonization';
-import * as Article from '@o2s/blocks.article/api-harmonization';
-import * as BentoGrid from '@o2s/blocks.bento-grid/api-harmonization';
-import * as Cart from '@o2s/blocks.cart/api-harmonization';
-import * as CategoryList from '@o2s/blocks.category-list/api-harmonization';
-import * as Category from '@o2s/blocks.category/api-harmonization';
-import * as CheckoutBillingPayment from '@o2s/blocks.checkout-billing-payment/api-harmonization';
-import * as CheckoutCompanyData from '@o2s/blocks.checkout-company-data/api-harmonization';
-import * as CheckoutShippingAddress from '@o2s/blocks.checkout-shipping-address/api-harmonization';
-import * as CheckoutSummary from '@o2s/blocks.checkout-summary/api-harmonization';
-import * as CtaSection from '@o2s/blocks.cta-section/api-harmonization';
-import * as Faq from '@o2s/blocks.faq/api-harmonization';
-import * as FeatureSectionGrid from '@o2s/blocks.feature-section-grid/api-harmonization';
-import * as FeatureSection from '@o2s/blocks.feature-section/api-harmonization';
-import * as FeaturedServiceList from '@o2s/blocks.featured-service-list/api-harmonization';
-import * as HeroSection from '@o2s/blocks.hero-section/api-harmonization';
-import * as InvoiceList from '@o2s/blocks.invoice-list/api-harmonization';
-import * as MediaSection from '@o2s/blocks.media-section/api-harmonization';
-import * as NotificationDetails from '@o2s/blocks.notification-details/api-harmonization';
-import * as NotificationList from '@o2s/blocks.notification-list/api-harmonization';
-import * as NotificationSummary from '@o2s/blocks.notification-summary/api-harmonization';
-import * as OrderConfirmation from '@o2s/blocks.order-confirmation/api-harmonization';
-import * as OrderDetails from '@o2s/blocks.order-details/api-harmonization';
-import * as OrderList from '@o2s/blocks.order-list/api-harmonization';
-import * as OrdersSummary from '@o2s/blocks.orders-summary/api-harmonization';
-import * as PaymentsHistory from '@o2s/blocks.payments-history/api-harmonization';
-import * as PaymentsSummary from '@o2s/blocks.payments-summary/api-harmonization';
-import * as PricingSection from '@o2s/blocks.pricing-section/api-harmonization';
-import * as ProductDetails from '@o2s/blocks.product-details/api-harmonization';
-import * as ProductList from '@o2s/blocks.product-list/api-harmonization';
-import * as QuickLinks from '@o2s/blocks.quick-links/api-harmonization';
-import * as RecommendedProducts from '@o2s/blocks.recommended-products/api-harmonization';
-import * as ServiceDetails from '@o2s/blocks.service-details/api-harmonization';
-import * as ServiceList from '@o2s/blocks.service-list/api-harmonization';
-import * as SurveyJsForm from '@o2s/blocks.surveyjs-form/api-harmonization';
-import * as TicketDetails from '@o2s/blocks.ticket-details/api-harmonization';
-import * as TicketList from '@o2s/blocks.ticket-list/api-harmonization';
-import * as TicketRecent from '@o2s/blocks.ticket-recent/api-harmonization';
-import * as TicketSummary from '@o2s/blocks.ticket-summary/api-harmonization';
-import * as UserAccount from '@o2s/blocks.user-account/api-harmonization';
-
-// BLOCK IMPORT
-
 import { AppConfig } from './app.config';
 import { AppService } from './app.service';
+import { blocks } from './blocks.config';
 import { configuration } from './config/configuration';
 import { ContextHeadersMiddleware } from './middleware/context-headers.middleware';
 import { HealthModule } from './modules/health/health.module';
@@ -151,48 +108,7 @@ export const DocumentsBaseModule = DocumentsModule.register({
         OrganizationsModule.register(AppConfig),
         SurveyJs.Module.register(AppConfig),
 
-        TicketList.Module.register(AppConfig),
-        TicketDetails.Module.register(AppConfig),
-        NotificationList.Module.register(AppConfig),
-        NotificationDetails.Module.register(AppConfig),
-        Faq.Module.register(AppConfig),
-        InvoiceList.Module.register(AppConfig),
-        PaymentsSummary.Module.register(AppConfig),
-        PaymentsHistory.Module.register(AppConfig),
-        UserAccount.Module.register(AppConfig),
-        TicketRecent.Module.register(AppConfig),
-        ServiceList.Module.register(AppConfig),
-        ServiceDetails.Module.register(AppConfig),
-        SurveyJsForm.Module.register(AppConfig),
-        OrderList.Module.register(AppConfig),
-        OrdersSummary.Module.register(AppConfig),
-        OrderDetails.Module.register(AppConfig),
-        QuickLinks.Module.register(AppConfig),
-        Category.Module.register(AppConfig),
-        CategoryList.Module.register(AppConfig),
-        Article.Module.register(AppConfig),
-        ArticleSearch.Module.register(AppConfig),
-        FeaturedServiceList.Module.register(AppConfig),
-        ArticleList.Module.register(AppConfig),
-        ProductList.Module.register(AppConfig),
-        NotificationSummary.Module.register(AppConfig),
-        TicketSummary.Module.register(AppConfig),
-        ProductDetails.Module.register(AppConfig),
-        RecommendedProducts.Module.register(AppConfig),
-        OrderConfirmation.Module.register(AppConfig),
-        CheckoutBillingPayment.Module.register(AppConfig),
-        CheckoutCompanyData.Module.register(AppConfig),
-        CheckoutShippingAddress.Module.register(AppConfig),
-        CheckoutSummary.Module.register(AppConfig),
-        Cart.Module.register(AppConfig),
-        HeroSection.Module.register(AppConfig),
-        BentoGrid.Module.register(AppConfig),
-        FeatureSection.Module.register(AppConfig),
-        CtaSection.Module.register(AppConfig),
-        MediaSection.Module.register(AppConfig),
-        PricingSection.Module.register(AppConfig),
-        FeatureSectionGrid.Module.register(AppConfig),
-        // BLOCK REGISTER
+        ...blocks.map((block) => block.Module.register(AppConfig)),
     ],
     providers: [
         AppService,

--- a/apps/api-harmonization/src/blocks.config.ts
+++ b/apps/api-harmonization/src/blocks.config.ts
@@ -1,0 +1,145 @@
+import * as ArticleList from '@o2s/blocks.article-list/api-harmonization';
+import * as ArticleSearch from '@o2s/blocks.article-search/api-harmonization';
+import * as Article from '@o2s/blocks.article/api-harmonization';
+import * as BentoGrid from '@o2s/blocks.bento-grid/api-harmonization';
+import * as Cart from '@o2s/blocks.cart/api-harmonization';
+import * as CategoryList from '@o2s/blocks.category-list/api-harmonization';
+import * as Category from '@o2s/blocks.category/api-harmonization';
+import * as CheckoutBillingPayment from '@o2s/blocks.checkout-billing-payment/api-harmonization';
+import * as CheckoutCompanyData from '@o2s/blocks.checkout-company-data/api-harmonization';
+import * as CheckoutShippingAddress from '@o2s/blocks.checkout-shipping-address/api-harmonization';
+import * as CheckoutSummary from '@o2s/blocks.checkout-summary/api-harmonization';
+import * as CtaSection from '@o2s/blocks.cta-section/api-harmonization';
+import * as Faq from '@o2s/blocks.faq/api-harmonization';
+import * as FeatureSectionGrid from '@o2s/blocks.feature-section-grid/api-harmonization';
+import * as FeatureSection from '@o2s/blocks.feature-section/api-harmonization';
+import * as FeaturedServiceList from '@o2s/blocks.featured-service-list/api-harmonization';
+import * as HeroSection from '@o2s/blocks.hero-section/api-harmonization';
+import * as InvoiceList from '@o2s/blocks.invoice-list/api-harmonization';
+import * as MediaSection from '@o2s/blocks.media-section/api-harmonization';
+import * as NotificationDetails from '@o2s/blocks.notification-details/api-harmonization';
+import * as NotificationList from '@o2s/blocks.notification-list/api-harmonization';
+import * as NotificationSummary from '@o2s/blocks.notification-summary/api-harmonization';
+import * as OrderConfirmation from '@o2s/blocks.order-confirmation/api-harmonization';
+import * as OrderDetails from '@o2s/blocks.order-details/api-harmonization';
+import * as OrderList from '@o2s/blocks.order-list/api-harmonization';
+import * as OrdersSummary from '@o2s/blocks.orders-summary/api-harmonization';
+import * as PaymentsHistory from '@o2s/blocks.payments-history/api-harmonization';
+import * as PaymentsSummary from '@o2s/blocks.payments-summary/api-harmonization';
+import * as PricingSection from '@o2s/blocks.pricing-section/api-harmonization';
+import * as ProductDetails from '@o2s/blocks.product-details/api-harmonization';
+import * as ProductList from '@o2s/blocks.product-list/api-harmonization';
+import * as QuickLinks from '@o2s/blocks.quick-links/api-harmonization';
+import * as RecommendedProducts from '@o2s/blocks.recommended-products/api-harmonization';
+import * as ServiceDetails from '@o2s/blocks.service-details/api-harmonization';
+import * as ServiceList from '@o2s/blocks.service-list/api-harmonization';
+import * as SurveyJsForm from '@o2s/blocks.surveyjs-form/api-harmonization';
+import * as TicketDetails from '@o2s/blocks.ticket-details/api-harmonization';
+import * as TicketList from '@o2s/blocks.ticket-list/api-harmonization';
+import * as TicketRecent from '@o2s/blocks.ticket-recent/api-harmonization';
+import * as TicketSummary from '@o2s/blocks.ticket-summary/api-harmonization';
+import * as UserAccount from '@o2s/blocks.user-account/api-harmonization';
+
+// BLOCK IMPORT
+
+/**
+ * Central registry of the blocks used by this app.
+ *
+ * To add a block:
+ *   1. `npm install` the block package (adds it to package.json),
+ *   2. add it to the `blocks` array below (its NestJS module is registered automatically in
+ *      `app.module.ts`),
+ *   3. add its `__typename` to the `Blocks` union below (the frontend renderer registry is checked
+ *      against this union at compile time).
+ *
+ * Both edits live in this one file. The block generator (`npm run generate`) does all of this for
+ * blocks scaffolded in this repo.
+ */
+export const blocks = [
+    Article,
+    ArticleList,
+    ArticleSearch,
+    BentoGrid,
+    Cart,
+    Category,
+    CategoryList,
+    CheckoutBillingPayment,
+    CheckoutCompanyData,
+    CheckoutShippingAddress,
+    CheckoutSummary,
+    CtaSection,
+    Faq,
+    FeatureSection,
+    FeatureSectionGrid,
+    FeaturedServiceList,
+    HeroSection,
+    InvoiceList,
+    MediaSection,
+    NotificationDetails,
+    NotificationList,
+    NotificationSummary,
+    OrderConfirmation,
+    OrderDetails,
+    OrderList,
+    OrdersSummary,
+    PaymentsHistory,
+    PaymentsSummary,
+    PricingSection,
+    ProductDetails,
+    ProductList,
+    QuickLinks,
+    RecommendedProducts,
+    ServiceDetails,
+    ServiceList,
+    SurveyJsForm,
+    TicketDetails,
+    TicketList,
+    TicketRecent,
+    TicketSummary,
+    UserAccount,
+    // BLOCK REGISTER
+];
+
+export type Blocks =
+    // BLOCK TYPE
+    | Article.Model.ArticleBlock['__typename']
+    | ArticleList.Model.ArticleListBlock['__typename']
+    | ArticleSearch.Model.ArticleSearchBlock['__typename']
+    | BentoGrid.Model.BentoGridBlock['__typename']
+    | Cart.Model.CartBlock['__typename']
+    | Category.Model.CategoryBlock['__typename']
+    | CategoryList.Model.CategoryListBlock['__typename']
+    | CheckoutBillingPayment.Model.CheckoutBillingPaymentBlock['__typename']
+    | CheckoutCompanyData.Model.CheckoutCompanyDataBlock['__typename']
+    | CheckoutShippingAddress.Model.CheckoutShippingAddressBlock['__typename']
+    | CheckoutSummary.Model.CheckoutSummaryBlock['__typename']
+    | CtaSection.Model.CtaSectionBlock['__typename']
+    | Faq.Model.FaqBlock['__typename']
+    | FeatureSection.Model.FeatureSectionBlock['__typename']
+    | FeatureSectionGrid.Model.FeatureSectionGridBlock['__typename']
+    | FeaturedServiceList.Model.FeaturedServiceListBlock['__typename']
+    | HeroSection.Model.HeroSectionBlock['__typename']
+    | InvoiceList.Model.InvoiceListBlock['__typename']
+    | MediaSection.Model.MediaSectionBlock['__typename']
+    | NotificationDetails.Model.NotificationDetailsBlock['__typename']
+    | NotificationList.Model.NotificationListBlock['__typename']
+    | NotificationSummary.Model.NotificationSummaryBlock['__typename']
+    | OrderConfirmation.Model.OrderConfirmationBlock['__typename']
+    | OrderDetails.Model.OrderDetailsBlock['__typename']
+    | OrderList.Model.OrderListBlock['__typename']
+    | OrdersSummary.Model.OrdersSummaryBlock['__typename']
+    | PaymentsHistory.Model.PaymentsHistoryBlock['__typename']
+    | PaymentsSummary.Model.PaymentsSummaryBlock['__typename']
+    | PricingSection.Model.PricingSectionBlock['__typename']
+    | ProductDetails.Model.ProductDetailsBlock['__typename']
+    | ProductList.Model.ProductListBlock['__typename']
+    | QuickLinks.Model.QuickLinksBlock['__typename']
+    | RecommendedProducts.Model.RecommendedProductsBlock['__typename']
+    | ServiceDetails.Model.ServiceDetailsBlock['__typename']
+    | ServiceList.Model.ServiceListBlock['__typename']
+    | SurveyJsForm.Model.SurveyjsBlock['__typename']
+    | TicketDetails.Model.TicketDetailsBlock['__typename']
+    | TicketList.Model.TicketListBlock['__typename']
+    | TicketRecent.Model.TicketRecentBlock['__typename']
+    | TicketSummary.Model.TicketSummaryBlock['__typename']
+    | UserAccount.Model.UserAccountBlock['__typename'];

--- a/apps/api-harmonization/src/modules/page/page.model.ts
+++ b/apps/api-harmonization/src/modules/page/page.model.ts
@@ -2,50 +2,6 @@ import { CMS } from '@o2s/configs.integrations';
 
 import { Models } from '@o2s/framework/modules';
 
-import * as ArticleList from '@o2s/blocks.article-list/api-harmonization';
-import * as ArticleSearch from '@o2s/blocks.article-search/api-harmonization';
-import * as Article from '@o2s/blocks.article/api-harmonization';
-import * as BentoGrid from '@o2s/blocks.bento-grid/api-harmonization';
-import * as Cart from '@o2s/blocks.cart/api-harmonization';
-import * as CategoryList from '@o2s/blocks.category-list/api-harmonization';
-import * as Category from '@o2s/blocks.category/api-harmonization';
-import * as CheckoutBillingPayment from '@o2s/blocks.checkout-billing-payment/api-harmonization';
-import * as CheckoutCompanyData from '@o2s/blocks.checkout-company-data/api-harmonization';
-import * as CheckoutShippingAddress from '@o2s/blocks.checkout-shipping-address/api-harmonization';
-import * as CheckoutSummary from '@o2s/blocks.checkout-summary/api-harmonization';
-import * as CtaSection from '@o2s/blocks.cta-section/api-harmonization';
-import * as Faq from '@o2s/blocks.faq/api-harmonization';
-import * as FeatureSectionGrid from '@o2s/blocks.feature-section-grid/api-harmonization';
-import * as FeatureSection from '@o2s/blocks.feature-section/api-harmonization';
-import * as FeaturedServiceList from '@o2s/blocks.featured-service-list/api-harmonization';
-import * as HeroSection from '@o2s/blocks.hero-section/api-harmonization';
-import * as BlockInvoiceList from '@o2s/blocks.invoice-list/api-harmonization';
-import * as MediaSection from '@o2s/blocks.media-section/api-harmonization';
-import * as NotificationDetails from '@o2s/blocks.notification-details/api-harmonization';
-import * as NotificationList from '@o2s/blocks.notification-list/api-harmonization';
-import * as NotificationSummary from '@o2s/blocks.notification-summary/api-harmonization';
-import * as OrderConfirmation from '@o2s/blocks.order-confirmation/api-harmonization';
-import * as OrderDetails from '@o2s/blocks.order-details/api-harmonization';
-import * as OrderList from '@o2s/blocks.order-list/api-harmonization';
-import * as OrdersSummary from '@o2s/blocks.orders-summary/api-harmonization';
-import * as PaymentsHistory from '@o2s/blocks.payments-history/api-harmonization';
-import * as PaymentsSummary from '@o2s/blocks.payments-summary/api-harmonization';
-import * as PricingSection from '@o2s/blocks.pricing-section/api-harmonization';
-import * as ProductDetails from '@o2s/blocks.product-details/api-harmonization';
-import * as ProductList from '@o2s/blocks.product-list/api-harmonization';
-import * as QuickLinks from '@o2s/blocks.quick-links/api-harmonization';
-import * as RecommendedProducts from '@o2s/blocks.recommended-products/api-harmonization';
-import * as ServiceDetails from '@o2s/blocks.service-details/api-harmonization';
-import * as ServiceList from '@o2s/blocks.service-list/api-harmonization';
-import * as Surveyjs from '@o2s/blocks.surveyjs-form/api-harmonization';
-import * as TicketDetails from '@o2s/blocks.ticket-details/api-harmonization';
-import * as TicketList from '@o2s/blocks.ticket-list/api-harmonization';
-import * as TicketRecent from '@o2s/blocks.ticket-recent/api-harmonization';
-import * as TicketSummary from '@o2s/blocks.ticket-summary/api-harmonization';
-import * as UserAccount from '@o2s/blocks.user-account/api-harmonization';
-
-// BLOCK IMPORT
-
 export class Init {
     locales!: {
         value: string;
@@ -94,46 +50,4 @@ export class PageData {
     breadcrumbs!: Breadcrumb[];
 }
 
-export type Blocks =
-    // BLOCK REGISTER
-    | Cart.Model.CartBlock['__typename']
-    | CheckoutSummary.Model.CheckoutSummaryBlock['__typename']
-    | CheckoutShippingAddress.Model.CheckoutShippingAddressBlock['__typename']
-    | CheckoutCompanyData.Model.CheckoutCompanyDataBlock['__typename']
-    | CheckoutBillingPayment.Model.CheckoutBillingPaymentBlock['__typename']
-    | OrderConfirmation.Model.OrderConfirmationBlock['__typename']
-    | RecommendedProducts.Model.RecommendedProductsBlock['__typename']
-    | ProductDetails.Model.ProductDetailsBlock['__typename']
-    | ProductList.Model.ProductListBlock['__typename']
-    | TicketSummary.Model.TicketSummaryBlock['__typename']
-    | NotificationSummary.Model.NotificationSummaryBlock['__typename']
-    | ArticleList.Model.ArticleListBlock['__typename']
-    | Category.Model.CategoryBlock['__typename']
-    | Article.Model.ArticleBlock['__typename']
-    | ArticleSearch.Model.ArticleSearchBlock['__typename']
-    | TicketList.Model.TicketListBlock['__typename']
-    | TicketDetails.Model.TicketDetailsBlock['__typename']
-    | NotificationList.Model.NotificationListBlock['__typename']
-    | NotificationDetails.Model.NotificationDetailsBlock['__typename']
-    | Faq.Model.FaqBlock['__typename']
-    | BlockInvoiceList.Model.InvoiceListBlock['__typename']
-    | PaymentsSummary.Model.PaymentsSummaryBlock['__typename']
-    | PaymentsHistory.Model.PaymentsHistoryBlock['__typename']
-    | UserAccount.Model.UserAccountBlock['__typename']
-    | TicketRecent.Model.TicketRecentBlock['__typename']
-    | ServiceList.Model.ServiceListBlock['__typename']
-    | ServiceDetails.Model.ServiceDetailsBlock['__typename']
-    | Surveyjs.Model.SurveyjsBlock['__typename']
-    | OrderList.Model.OrderListBlock['__typename']
-    | OrdersSummary.Model.OrdersSummaryBlock['__typename']
-    | OrderDetails.Model.OrderDetailsBlock['__typename']
-    | QuickLinks.Model.QuickLinksBlock['__typename']
-    | CategoryList.Model.CategoryListBlock['__typename']
-    | FeaturedServiceList.Model.FeaturedServiceListBlock['__typename']
-    | HeroSection.Model.HeroSectionBlock['__typename']
-    | BentoGrid.Model.BentoGridBlock['__typename']
-    | FeatureSection.Model.FeatureSectionBlock['__typename']
-    | CtaSection.Model.CtaSectionBlock['__typename']
-    | MediaSection.Model.MediaSectionBlock['__typename']
-    | PricingSection.Model.PricingSectionBlock['__typename']
-    | FeatureSectionGrid.Model.FeatureSectionGridBlock['__typename'];
+export type { Blocks } from '../../blocks.config';

--- a/apps/docs/docs/guides/using-generators.md
+++ b/apps/docs/docs/guides/using-generators.md
@@ -21,7 +21,7 @@ at the root level of the project, after which you will be asked which generator 
 You can create a new block within the `api-harmonization` app by using `block` generator. It will:
 
 1. Ask you for the block name.
-2. Ask you for the block domain (`content`, `marketing`, `services`, `commerce`, `billing`, `support`, `notifications`, `account`, `navigation`, `forms`).
+2. Ask you for the block domain (`content`, `knowledge-base`, `services`, `orders`, `products`, `checkout`, `billing`, `support`, `notifications`, `account`, `forms`).
 3. Ask which project templates should include this block (`o2s`, `dxp`, or leave empty for custom-only). This sets the `o2sTemplate` field in `package.json`, used by the `create-o2s-app` CLI wizard to determine which blocks belong to each template.
 4. Create a new package in the `packages/blocks/<domain>/<block-name>` directory.
 5. Inside this new folder, it will create all the necessary files that compose a block:

--- a/apps/docs/docs/guides/using-generators.md
+++ b/apps/docs/docs/guides/using-generators.md
@@ -39,7 +39,7 @@ You can create a new block within the `api-harmonization` app by using `block` g
         - API methods,
     3. SDK part.
 6. Register the block automatically, so no manual wiring is needed:
-    - register it in the API Harmonization app (`app.module.ts` and the `page.model.ts` block union) and in the framework CMS block model,
+    - add it to the API Harmonization block config (`apps/api-harmonization/src/blocks.config.ts` — the module array and the `Blocks` union) and to the framework CMS block model,
     - add its renderer to the frontend registry (`renderBlocks.tsx`),
     - add `@o2s/blocks.<block-name>` to the `dependencies` of both `apps/api-harmonization` and `apps/frontend`.
 

--- a/apps/docs/docs/guides/using-generators.md
+++ b/apps/docs/docs/guides/using-generators.md
@@ -38,6 +38,12 @@ You can create a new block within the `api-harmonization` app by using `block` g
         - typings,
         - API methods,
     3. SDK part.
+6. Register the block automatically, so no manual wiring is needed:
+    - register it in the API Harmonization app (`app.module.ts` and the `page.model.ts` block union) and in the framework CMS block model,
+    - add its renderer to the frontend registry (`renderBlocks.tsx`),
+    - add `@o2s/blocks.<block-name>` to the `dependencies` of both `apps/api-harmonization` and `apps/frontend`.
+
+After the generator finishes, the only remaining step is to run `npm install` so the new workspace package is linked.
 
 ---
 

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -458,27 +458,21 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
                 },
                 {
                     type: 'modify',
-                    path: 'apps/api-harmonization/src/app.module.ts',
+                    path: 'apps/api-harmonization/src/blocks.config.ts',
                     pattern: /(\/\/ BLOCK IMPORT)/g,
                     template: `import * as {{pascalCase name}} from '@o2s/blocks.{{kebabCase name}}/api-harmonization';\n// BLOCK IMPORT`,
                 },
                 {
                     type: 'modify',
-                    path: 'apps/api-harmonization/src/app.module.ts',
+                    path: 'apps/api-harmonization/src/blocks.config.ts',
                     pattern: /(\/\/ BLOCK REGISTER)/g,
-                    template: `{{pascalCase name}}.Module.register(AppConfig),\n        // BLOCK REGISTER`,
+                    template: `{{pascalCase name}},\n    // BLOCK REGISTER`,
                 },
                 {
                     type: 'modify',
-                    path: 'apps/api-harmonization/src/modules/page/page.model.ts',
-                    pattern: /(\/\/ BLOCK IMPORT)/g,
-                    template: `import * as {{pascalCase name}} from '@o2s/blocks.{{kebabCase name}}/api-harmonization';\n// BLOCK IMPORT`,
-                },
-                {
-                    type: 'modify',
-                    path: 'apps/api-harmonization/src/modules/page/page.model.ts',
-                    pattern: /(\/\/ BLOCK REGISTER)/g,
-                    template: `// BLOCK REGISTER\n    | {{pascalCase name}}.Model.{{pascalCase name}}Block['__typename']`,
+                    path: 'apps/api-harmonization/src/blocks.config.ts',
+                    pattern: /(\/\/ BLOCK TYPE)/g,
+                    template: `// BLOCK TYPE\n    | {{pascalCase name}}.Model.{{pascalCase name}}Block['__typename']`,
                 },
 
                 // FRONTEND

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -1,4 +1,37 @@
 import type { PlopTypes } from '@turbo/gen';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Adds a workspace dependency to a package.json's `dependencies`, inserted alphabetically among the
+ * existing keys (in place, without reordering the rest). Returns the new file content, or the
+ * original content unchanged when the dependency is already present. Pure and idempotent.
+ */
+export function addBlockDependency(content: string, packageName: string, version = '*'): string {
+    const pkg = JSON.parse(content) as { dependencies?: Record<string, string> };
+    const deps = pkg.dependencies ?? {};
+
+    if (deps[packageName]) {
+        return content;
+    }
+
+    const next: Record<string, string> = {};
+    let inserted = false;
+    for (const [key, value] of Object.entries(deps)) {
+        if (!inserted && key > packageName) {
+            next[packageName] = version;
+            inserted = true;
+        }
+        next[key] = value;
+    }
+    if (!inserted) {
+        next[packageName] = version;
+    }
+
+    pkg.dependencies = next;
+
+    return `${JSON.stringify(pkg, null, 4)}\n`;
+}
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
     // Register custom Handlebars helper for conditional checks
@@ -575,6 +608,30 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
                 },
             ];
 
+            // Register the block as a dependency of both apps so it resolves as a workspace package.
+            actions.push(() => {
+                const kebabBlockName = plop.getHelper('kebabCase')(String(data?.name ?? '').trim()) as string;
+                const packageName = `@o2s/blocks.${kebabBlockName}`;
+                const basePath = plop.getDestBasePath() || process.cwd();
+
+                const appPackageJsonPaths = ['apps/api-harmonization/package.json', 'apps/frontend/package.json'];
+
+                const updated: string[] = [];
+                for (const relativePath of appPackageJsonPaths) {
+                    const absolutePath = path.join(basePath, relativePath);
+                    const before = fs.readFileSync(absolutePath, 'utf8');
+                    const after = addBlockDependency(before, packageName);
+                    if (after !== before) {
+                        fs.writeFileSync(absolutePath, after);
+                        updated.push(relativePath);
+                    }
+                }
+
+                return updated.length > 0
+                    ? `Added "${packageName}": "*" to: ${updated.join(', ')}`
+                    : `"${packageName}" already present in the app package.json files`;
+            });
+
             actions.push(() => {
                 const blockName = String(data?.name ?? '').trim();
                 const blockDomain = String(data?.domain ?? '').trim();
@@ -589,11 +646,11 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
                     `  ${blockRootPath}/src/frontend/`,
                     `  ${blockRootPath}/src/sdk/`,
                     '',
+                    'The block has been registered and added to both apps automatically.',
+                    '',
                     'Next steps:',
-                    `  1. Add "${packageName}": "*" to apps/api-harmonization/package.json`,
-                    `  2. Add "${packageName}": "*" to apps/frontend/package.json`,
-                    '  3. Run: npm install',
-                    '  4. Run: npm run lint (optional sanity check)',
+                    '  1. Run: npm install',
+                    '  2. Run: npm run lint (optional sanity check)',
                 ].join('\n');
             });
 


### PR DESCRIPTION
## What and why

Closes #769.

Adding a block used to require editing several files by hand. This reduces it to a minimal, obvious task, which matters most for a downstream project adopting a published block package.

## Changes

**1. The generator registers a block in both apps automatically.** The block generator already injected the registration markers; it now also adds `@o2s/blocks.<name>` to the dependencies of `apps/api-harmonization` and `apps/frontend` (inserted alphabetically, in place). So `npm run generate` scaffolds and fully wires a block with zero manual file edits, and the only follow-up is `npm install`.

**2. Backend registration is centralized in one file.** A new `apps/api-harmonization/src/blocks.config.ts` holds the block module array and the `Blocks` union. `app.module.ts` registers every block via `...blocks.map((block) => block.Module.register(AppConfig))`, and `page.model.ts` re-exports `Blocks`. Previously this was split across `app.module.ts` and `page.model.ts`; now it is a single source of truth.

The frontend already had one registration point (`renderBlocks.tsx`), so it is unchanged. Its `satisfies Record<Blocks, BlockRenderer>` check still enforces backend/frontend parity at compile time.

## Adding a block in a downstream project

A project based on this repo can adopt a published block with:

1. `npm install <block-package>` (npm adds the dependency),
2. add it to `apps/api-harmonization/src/blocks.config.ts` (one entry in the `blocks` array and one member in the `Blocks` union),
3. add its renderer to `apps/frontend/src/blocks/renderBlocks.tsx`.

Two config files, and no edits to `app.module.ts` or `page.model.ts`.

## Testing

- `npm run build`, `npm run lint`, `npm run test` all pass across the monorepo.
- Ran the block generator end to end: it scaffolds the block and injects into `blocks.config.ts`, `renderBlocks.tsx`, the CMS block model, and both app `package.json` files.
- Ran both apps and verified in the browser that dashboard, invoices, notifications, services, orders, and cases render their blocks (payments summary/history, invoice list, notifications, services, orders summary/list, ticket summary/list, quick links), with no unknown-block warnings and no console errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized page-block registration for API Harmonization.
  * Block generation now automatically registers new blocks and adds required application packages.
  * Added compile-time validation for supported page block types.
* **Documentation**
  * Updated generator guidance to reflect automatic registration and the remaining installation step.
* **Improvements**
  * Improved dependency handling to preserve consistent package formatting during block generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->