### PR TITLE
chore(deps): drop obsolete webpack override (float to 5.110.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17191,18 +17191,11 @@
         },
         "node_modules/@types/eslint": {
             "version": "9.6.1",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
-            }
-        },
-        "node_modules/@types/eslint-scope": {
-            "version": "3.7.7",
-            "license": "MIT",
-            "dependencies": {
-                "@types/eslint": "*",
-                "@types/estree": "*"
             }
         },
         "node_modules/@types/estree": {
@@ -19107,16 +19100,6 @@
             },
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-import-phases": {
-            "version": "1.0.4",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "peerDependencies": {
-                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-jsx": {
@@ -26130,10 +26113,6 @@
                 "tslib": "2"
             }
         },
-        "node_modules/glob-to-regexp": {
-            "version": "0.4.1",
-            "license": "BSD-2-Clause"
-        },
         "node_modules/global-directory": {
             "version": "5.0.0",
             "dev": true,
@@ -29937,17 +29916,6 @@
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
-        "node_modules/loader-runner": {
-            "version": "4.3.2",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.11.5"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/loader-utils": {
             "version": "2.0.4",
             "license": "MIT",
@@ -32620,6 +32588,143 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/minimizer-webpack-plugin": {
+            "version": "5.9.0",
+            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.9.0.tgz",
+            "integrity": "sha512-OASqv+dewv8vjkOBjqMOHvxUaXhtGBLZAXq7JbmYE8TSzBvOswiGq5JcBdc8ypuLL/8YUT1OEyupga6/iqdyTA==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^4.3.3",
+                "terser": "^5.51.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@minify-html/node": {
+                    "optional": true
+                },
+                "@napi-rs/image": {
+                    "optional": true
+                },
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/css": {
+                    "optional": true
+                },
+                "@swc/html": {
+                    "optional": true
+                },
+                "clean-css": {
+                    "optional": true
+                },
+                "cssnano": {
+                    "optional": true
+                },
+                "csso": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "html-minifier-terser": {
+                    "optional": true
+                },
+                "imagemin": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "postcss": {
+                    "optional": true
+                },
+                "sharp": {
+                    "optional": true
+                },
+                "svgo": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/minimizer-webpack-plugin/node_modules/ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/minimizer-webpack-plugin/node_modules/jest-worker": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/minimizer-webpack-plugin/node_modules/schema-utils": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/minimizer-webpack-plugin/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/minipass": {
@@ -43754,34 +43859,30 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
-            "version": "5.104.1",
+            "version": "5.110.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.3.tgz",
+            "integrity": "sha512-GuizBzRvo9YPpyoNMf3ag7AzxbaW85qrRSqTha345KyJbAFPt3/cMzBM0h+RWg7SK/7DdzRLINP3LvQ0hvr4hg==",
             "license": "MIT",
             "dependencies": {
-                "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.15.0",
-                "acorn-import-phases": "^1.0.3",
+                "acorn": "^8.16.0",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.4",
-                "es-module-lexer": "^2.0.0",
-                "eslint-scope": "5.1.1",
+                "enhanced-resolve": "^5.24.4",
+                "es-module-lexer": "^2.1.0",
                 "events": "^3.2.0",
-                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
-                "json-parse-even-better-errors": "^2.3.1",
-                "loader-runner": "^4.3.1",
-                "mime-types": "^2.1.27",
+                "mime-db": "^1.54.0",
+                "minimizer-webpack-plugin": "^5.7.0",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
-                "terser-webpack-plugin": "^5.3.16",
-                "watchpack": "^2.4.4",
-                "webpack-sources": "^3.3.3"
+                "watchpack": "^2.5.2",
+                "webpack-sources": "^3.5.1"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -44504,41 +44605,6 @@
                 "ajv": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/webpack/node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/webpack/node_modules/estraverse": {
-            "version": "4.3.0",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/webpack/node_modules/mime-db": {
-            "version": "1.52.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/webpack/node_modules/mime-types": {
-            "version": "2.1.35",
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/webpack/node_modules/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -95,8 +95,7 @@
         "unzipper": "^0.12.5"
     },
     "overrides": {
-        "@swc/core": "1.16.1",
-        "webpack": "5.104.1"
+        "@swc/core": "1.16.1"
     },
     "allowScripts": {
         "postman-code-generators": true,


### PR DESCRIPTION
## Summary

Removes the `webpack@5.104.1` override so webpack floats to **5.110.3**.

The override was a workaround from an earlier dependency pass: webpack 5.106+'s ESM analysis broke `motion-dom`'s `warnOnce` import from `motion-utils` in the Docusaurus bundle, so webpack was pinned to 5.104.1. Two things have since changed:

1. **The motion libraries moved to 13.x** (framer-motion / motion-dom 13.2.0, motion-utils 13.0.0) — a major bump that restructured those ESM exports, so the original break no longer occurs.
2. **`@nestjs/cli` requires `webpack ^5.105.4`** — meaning the `5.104.1` pin was actually holding webpack *below* a stated requirement (the override masked the violation).

Dropping the override resolves both: webpack floats to 5.110.3, satisfying every consumer, and the latent constraint violation is gone. A *fixed* override bumped to 5.110.3 was avoided deliberately — it would recreate the same pin-below-requirement trap on the next `@nestjs/cli`/Docusaurus bump.

## Scope

Only **Docusaurus** uses this webpack. The frontend (Next.js) has its own bundled webpack; api-harmonization builds with `tsc7`; Storybook uses Vite. So the docs site is the entire surface.

## Verification

- Docs production build (`turbo run build --filter=@o2s/docs --force`) green with webpack 5.110.3.
- Browser check of the served docs site — clean console, animations render (the motion-dom regression would have surfaced here).
- Full `turbo run build lint test` green (181/181).