### PR TITLE
chore(release): version private packages in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": { "version": true, "tag": false }
 }


### PR DESCRIPTION
## Summary

`.changeset/config.json` left `privatePackages` unset, so Changesets skipped versioning the repo's **private** packages — `@o2s/ui`, `@o2s/configs.integrations`, `@o2s/modules.documents`. But their (non-private) dependents — blocks, modules, integrations — still declare dependencies on them, so Changesets couldn't build a consistent release tree: `changeset status` reported **88 "Invalid tree" errors** and exited non-zero.

This surfaced via a CodeRabbit comment on #885 (the `@o2s/ui` entry in a changeset wouldn't version). It's a pre-existing, repo-wide condition though — changesets across the repo routinely list these private packages (`seo-friendly-filter-urls`, `list-blocks-ssr-filters`, `url-filters-*`, etc.), so the right fix is central, not per-PR.

## Change

```json
"privatePackages": { "version": true, "tag": false }
```

- **`version: true`** — private packages are versioned (and their dependents bump consistently via `updateInternalDependencies`).
- **`tag: false`** — no git tags for them (they aren't released artifacts).
- `changeset publish` still skips `private: true` packages, so **nothing new gets published** — this only makes local versioning/changelogs consistent.

## Verification

`changeset status`:
- **before:** 88 "Invalid tree" errors, exit 1
- **after:** 0 errors, exit 0 — `@o2s/ui`, `@o2s/configs.integrations`, `@o2s/modules.documents` now appear in the release set alongside their dependents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to control versioning and tagging behavior for private packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->