### PR TITLE
feat(framework): normalize SDK request errors

### DIFF
--- a/.changeset/unify-sdk-api-request-errors.md
+++ b/.changeset/unify-sdk-api-request-errors.md
@@ -1,0 +1,7 @@
+---
+'@o2s/framework': minor
+---
+
+feat(framework): normalize errors from every SDK request
+
+SDK methods now reject with the framework-level `ApiRequestError` for transport, HTTP and response parsing failures. The error exposes the request method and URL together with the status, response data and original cause when available. `BlockRequestError` remains a deprecated alias for compatibility with block SDK consumers.

--- a/apps/frontend/src/app/[locale]/[[...slug]]/page.tsx
+++ b/apps/frontend/src/app/[locale]/[[...slug]]/page.tsx
@@ -4,6 +4,8 @@ import { headers } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
 import React from 'react';
 
+import { ApiRequestError } from '@o2s/framework/sdk';
+
 import { GlobalProvider } from '@o2s/ui/providers/GlobalProvider';
 
 import { AppSpinner } from '@o2s/ui/components/Feedback/AppSpinner';
@@ -166,21 +168,11 @@ export default async function Page({ params, searchParams }: Props) {
             </body>
         );
     } catch (error) {
-        if (
-            // @ts-expect-error TODO add proper error type detection
-            (error && 'status' in error && error.status === 404) ||
-            // @ts-expect-error TODO add proper error type detection
-            (error && 'response' in error && 'status' in error.response && error.response.status === 404)
-        ) {
+        if (error instanceof ApiRequestError && error.status === 404) {
             notFound();
         }
 
-        if (
-            // @ts-expect-error TODO add proper error type detection
-            (error && 'status' in error && error.status === 401) ||
-            // @ts-expect-error TODO add proper error type detection
-            (error && 'response' in error && 'status' in error.response && error.response.status === 401)
-        ) {
+        if (error instanceof ApiRequestError && error.status === 401) {
             if (!session?.user) {
                 return await signIn();
             } else {

--- a/packages/framework/src/interceptors.spec.ts
+++ b/packages/framework/src/interceptors.spec.ts
@@ -1,0 +1,69 @@
+import type { FetchContext, FetchResponse } from 'ofetch';
+import { describe, expect, it } from 'vitest';
+
+import { createInterceptors } from './interceptors';
+import { ApiRequestError } from './utils/api-request-error';
+
+const requestContext = (
+    error: Error,
+    request: FetchContext['request'] = '/tickets/1',
+    baseURL?: string,
+): FetchContext & { error: Error } => ({
+    request,
+    options: { method: 'GET', headers: new Headers(), baseURL },
+    error,
+});
+
+const responseContext = (status: number, statusText: string, data: unknown) =>
+    ({
+        request: '/tickets/1',
+        options: { method: 'GET', headers: new Headers() },
+        response: {
+            status,
+            statusText,
+            _data: data,
+        },
+    }) as unknown as FetchContext & { response: FetchResponse<unknown> };
+
+describe('request error interceptors', () => {
+    it('wraps transport failures in ApiRequestError', async () => {
+        const cause = new Error('Failed to fetch');
+        const { onRequestError } = createInterceptors({});
+
+        await expect(
+            onRequestError(requestContext(cause, 'https://api.example.com/tickets/1', 'https://api.example.com')),
+        ).rejects.toMatchObject({
+            name: 'ApiRequestError',
+            message: '[GET /tickets/1] Failed to fetch',
+            method: 'get',
+            url: '/tickets/1',
+            cause,
+        });
+    });
+
+    it('wraps HTTP failures and preserves the response payload', async () => {
+        const { onResponseError } = createInterceptors({});
+
+        await expect(onResponseError(responseContext(404, 'Not Found', { code: 'missing' }))).rejects.toMatchObject({
+            name: 'ApiRequestError',
+            message: '[GET /tickets/1] 404 Not Found',
+            status: 404,
+            data: { code: 'missing' },
+            response: {
+                status: 404,
+                data: { code: 'missing' },
+            },
+        });
+    });
+
+    it('does not replace an error that was already normalized', async () => {
+        const original = new ApiRequestError('[GET /tickets/1] 401 Unauthorized', {
+            method: 'get',
+            url: '/tickets/1',
+            status: 401,
+        });
+        const { onRequestError } = createInterceptors({});
+
+        await expect(onRequestError(requestContext(original))).rejects.toBe(original);
+    });
+});

--- a/packages/framework/src/interceptors.ts
+++ b/packages/framework/src/interceptors.ts
@@ -1,23 +1,31 @@
-import { FetchContext, FetchError, FetchResponse } from 'ofetch';
+import { FetchContext, FetchResponse } from 'ofetch';
 
+import { toApiRequestError } from './utils/api-request-error';
 import { ErrorType, LoggerConfig, LoggerService, RequestConfig, ResponseType } from './utils/logger';
-
-const parseError = (error: Error | FetchError) => {
-    if (error instanceof FetchError && error.response) {
-        return Promise.reject({
-            status: error.response.status || error.statusCode,
-            message: error.message,
-            data: error.response._data,
-        });
-    }
-    return Promise.reject(error);
-};
 
 export interface InterceptorsConfig {
     logger?: LoggerConfig;
 }
 
 export type FetchHookType<T> = (context: T) => Promise<void> | void;
+
+const getRequestUrl = (request: FetchContext['request'], baseURL?: string): string => {
+    const requestUrl = typeof request === 'string' ? request : request.url;
+
+    if (!baseURL) {
+        return requestUrl;
+    }
+
+    const normalizedBaseURL = baseURL.endsWith('/') ? baseURL.slice(0, -1) : baseURL;
+
+    if (requestUrl !== normalizedBaseURL && !requestUrl.startsWith(`${normalizedBaseURL}/`)) {
+        return requestUrl;
+    }
+
+    const relativeUrl = requestUrl.slice(normalizedBaseURL.length);
+
+    return relativeUrl ? (relativeUrl.startsWith('/') ? relativeUrl : `/${relativeUrl}`) : '/';
+};
 
 export interface FetchInterceptors {
     onRequest: FetchHookType<FetchContext>;
@@ -65,6 +73,7 @@ export const createInterceptors = ({ logger }: InterceptorsConfig): FetchInterce
 
     const onRequestError: FetchInterceptors['onRequestError'] = (context) => {
         const { request, options, error } = context;
+        const requestUrl = getRequestUrl(request, options.baseURL);
 
         const errorObject: ErrorType = {
             name: error.name,
@@ -79,11 +88,12 @@ export const createInterceptors = ({ logger }: InterceptorsConfig): FetchInterce
         };
 
         loggerService.apiRequestError(errorObject);
-        return parseError(error);
+        return Promise.reject(toApiRequestError(error, options.method || 'GET', requestUrl));
     };
 
     const onResponseError: FetchInterceptors['onResponseError'] = (context) => {
         const { request, options, response } = context;
+        const requestUrl = getRequestUrl(request, options.baseURL);
 
         const errorObject: ErrorType = {
             name: 'ResponseError',
@@ -110,7 +120,7 @@ export const createInterceptors = ({ logger }: InterceptorsConfig): FetchInterce
         };
 
         loggerService.apiResponseError(errorObject);
-        return parseError(errorObject);
+        return Promise.reject(toApiRequestError(errorObject, options.method || 'GET', requestUrl));
     };
 
     return {

--- a/packages/framework/src/sdk.spec.ts
+++ b/packages/framework/src/sdk.spec.ts
@@ -2,6 +2,7 @@ import type { FetchOptions } from 'ofetch';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getSdk } from './sdk';
+import { ApiRequestError } from './utils/api-request-error';
 
 const ofetchInstance = vi.fn(async (_url: string, _options?: FetchOptions) => ({}));
 
@@ -30,5 +31,22 @@ describe('makeRequest', () => {
         await sdk.makeRequest({ url: '/invoices' });
 
         expect(lastOptions()).not.toHaveProperty('responseType');
+    });
+
+    it('should normalize response parsing failures at the SDK boundary', async () => {
+        const cause = new SyntaxError('Unexpected end of JSON input');
+        ofetchInstance.mockRejectedValueOnce(cause);
+        const sdk = getSdk({ apiUrl: 'https://api.example.com' });
+
+        const error = await sdk.makeRequest({ url: '/tickets/1' }).catch((caught: unknown) => caught);
+
+        expect(error).toBeInstanceOf(ApiRequestError);
+        expect(error).toMatchObject({
+            name: 'ApiRequestError',
+            message: '[GET /tickets/1] Unexpected end of JSON input',
+            method: 'get',
+            url: '/tickets/1',
+            cause,
+        });
     });
 });

--- a/packages/framework/src/sdk.ts
+++ b/packages/framework/src/sdk.ts
@@ -5,6 +5,7 @@ import { getNotification, getNotifications, markAs } from './api/notifications';
 import { createTicket, getTicket, getTickets } from './api/tickets';
 import { getCustomerForCurrentUserById, getDefaultCustomerForCurrentUser, getUser } from './api/users';
 import { createInterceptors } from './interceptors';
+import { toApiRequestError } from './utils/api-request-error';
 import type { BlockResponseType } from './utils/block-request';
 import { LoggerConfig } from './utils/logger';
 import { AppHeaders } from './utils/models/headers';
@@ -104,7 +105,10 @@ export const getSdk = ({ apiUrl, logger }: SdkConfig): Sdk => {
         }
 
         const url = config.url || '';
-        return ofetchInstance(url, fetchOptions) as Promise<T>;
+
+        return ofetchInstance(url, fetchOptions).catch((error: unknown) => {
+            throw toApiRequestError(error, config.method || 'GET', url);
+        }) as Promise<T>;
     };
 
     // Define API method groups here

--- a/packages/framework/src/sdk.ts
+++ b/packages/framework/src/sdk.ts
@@ -9,7 +9,7 @@ import type { BlockResponseType } from './utils/block-request';
 import { LoggerConfig } from './utils/logger';
 import { AppHeaders } from './utils/models/headers';
 
-export { BlockRequestError, createBlockRequest } from './utils/block-request';
+export { ApiRequestError, BlockRequestError, createBlockRequest } from './utils/block-request';
 export type {
     BlockRequest,
     BlockRequestConfig,

--- a/packages/framework/src/utils/api-request-error.ts
+++ b/packages/framework/src/utils/api-request-error.ts
@@ -1,0 +1,81 @@
+export interface ApiRequestErrorResponse {
+    status?: number;
+    data?: unknown;
+    [key: string]: unknown;
+}
+
+export interface ApiRequestErrorOptions {
+    method: string;
+    url: string;
+    status?: number;
+    data?: unknown;
+    response?: ApiRequestErrorResponse;
+    cause?: unknown;
+}
+
+const toStatus = (value: unknown): number | undefined => {
+    return typeof value === 'number' ? value : undefined;
+};
+
+/**
+ * Error thrown by every SDK request. It normalizes transport, HTTP and response parsing failures while
+ * keeping the original error available as `cause`.
+ */
+export class ApiRequestError extends Error {
+    /** HTTP method of the failed request. */
+    readonly method: string;
+    /** URL of the failed request. */
+    readonly url: string;
+    /** HTTP status code, when the request reached the server. */
+    readonly status?: number;
+    /** Response payload returned by the server. */
+    readonly data?: unknown;
+    /** Raw response details, as returned by the underlying fetch client. */
+    readonly response?: ApiRequestErrorResponse;
+
+    constructor(message: string, options: ApiRequestErrorOptions) {
+        super(message, { cause: options.cause });
+
+        this.name = 'ApiRequestError';
+        this.method = options.method;
+        this.url = options.url;
+        this.status = options.status;
+        this.data = options.data;
+        this.response = options.response;
+    }
+}
+
+interface ApiRequestErrorSource {
+    message?: unknown;
+    status?: unknown;
+    statusCode?: unknown;
+    data?: unknown;
+    response?: ApiRequestErrorResponse;
+}
+
+/**
+ * Converts an arbitrary request failure into the framework error contract. Existing framework errors are
+ * returned unchanged so wrappers such as `createBlockRequest` do not replace the original instance.
+ */
+export const toApiRequestError = (error: unknown, method: string, url: string): ApiRequestError => {
+    if (error instanceof ApiRequestError) {
+        return error;
+    }
+
+    const source = (typeof error === 'object' && error !== null ? error : {}) as ApiRequestErrorSource;
+    const normalizedMethod = method.toLowerCase();
+    const status = toStatus(source.status) ?? toStatus(source.statusCode) ?? toStatus(source.response?.status);
+    const message = typeof source.message === 'string' && source.message ? source.message : 'Request failed';
+
+    return new ApiRequestError(
+        `[${normalizedMethod.toUpperCase()} ${url}]${status !== undefined ? ` ${status}` : ''} ${message}`,
+        {
+            method: normalizedMethod,
+            url,
+            status,
+            data: source.data ?? source.response?.data ?? source.response?._data,
+            response: source.response,
+            cause: error,
+        },
+    );
+};

--- a/packages/framework/src/utils/block-request.spec.ts
+++ b/packages/framework/src/utils/block-request.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { CompatRequestConfig, Sdk } from '../sdk';
 
-import { type BlockRequestConfig, BlockRequestError, createBlockRequest } from './block-request';
+import { ApiRequestError, type BlockRequestConfig, BlockRequestError, createBlockRequest } from './block-request';
 import { HeaderName } from './models/headers';
 
 const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -148,8 +148,13 @@ describe('createBlockRequest', () => {
             const error = await failWith({ status: 404, message: 'Not Found' });
 
             expect(error).toBeInstanceOf(BlockRequestError);
+            expect(error).toBeInstanceOf(ApiRequestError);
             expect(error.status).toBe(404);
             expect(error.message).toBe('[GET /tickets] 404 Not Found');
+        });
+
+        it('should keep the deprecated block error export as an alias', () => {
+            expect(BlockRequestError).toBe(ApiRequestError);
         });
 
         it('should take the status of an error that calls it statusCode', async () => {
@@ -188,8 +193,17 @@ describe('createBlockRequest', () => {
             expect((await failWith(cause)).cause).toBe(cause);
         });
 
+        it('should use the backstop for response parsing failures', async () => {
+            const cause = new SyntaxError('Unexpected token');
+            const error = await failWith(cause);
+
+            expect(error).toBeInstanceOf(ApiRequestError);
+            expect(error.message).toBe('[GET /tickets] Unexpected token');
+            expect(error.cause).toBe(cause);
+        });
+
         it('should not wrap an error that is already a BlockRequestError', async () => {
-            const original = new BlockRequestError('[GET /tickets] 404 Not Found', {
+            const original = new ApiRequestError('[GET /tickets] 404 Not Found', {
                 method: 'get',
                 url: '/tickets',
                 status: 404,

--- a/packages/framework/src/utils/block-request.ts
+++ b/packages/framework/src/utils/block-request.ts
@@ -1,7 +1,13 @@
 import type { CompatRequestConfig, Sdk } from '../sdk';
 
 import { getApiHeaders } from './api-headers';
+import { ApiRequestError, toApiRequestError } from './api-request-error';
 import { AppHeaders, HeaderName } from './models/headers';
+
+export { ApiRequestError } from './api-request-error';
+
+/** @deprecated Use {@link ApiRequestError} instead. */
+export { ApiRequestError as BlockRequestError } from './api-request-error';
 
 export type BlockRequestMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
 
@@ -34,48 +40,6 @@ export interface BlockRequestConfig {
  * Performs a single request to the API Harmonization Server, with the response typed as `TResponse`.
  */
 export type BlockRequest = <TResponse>(config: BlockRequestConfig) => Promise<TResponse>;
-
-interface BlockRequestErrorOptions {
-    method: BlockRequestMethod;
-    url: string;
-    status?: number;
-    data?: unknown;
-    response?: BlockErrorResponse;
-    cause?: unknown;
-}
-
-interface BlockErrorResponse {
-    status?: number;
-    data?: unknown;
-}
-
-/**
- * Error thrown by every method created with {@link createBlockRequest}. It normalizes the various error
- * shapes returned by the underlying fetch client and keeps the original error available as `cause`.
- */
-export class BlockRequestError extends Error {
-    /** HTTP method of the failed request. */
-    readonly method: BlockRequestMethod;
-    /** URL of the failed request. */
-    readonly url: string;
-    /** HTTP status code, when the request reached the server. */
-    readonly status?: number;
-    /** Response payload returned by the server. */
-    readonly data?: unknown;
-    /** Raw response details, as returned by the underlying fetch client. */
-    readonly response?: BlockErrorResponse;
-
-    constructor(message: string, options: BlockRequestErrorOptions) {
-        super(message, { cause: options.cause });
-
-        this.name = 'BlockRequestError';
-        this.method = options.method;
-        this.url = options.url;
-        this.status = options.status;
-        this.data = options.data;
-        this.response = options.response;
-    }
-}
 
 const mergeHeaders = (headers?: BlockRequestHeaders, authorization?: string): Record<string, string> => {
     const merged: Record<string, string> = getApiHeaders();
@@ -113,40 +77,18 @@ const serializeParams = (params: unknown): unknown => {
     return Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined));
 };
 
-const toStatus = (value: unknown): number | undefined => {
-    return typeof value === 'number' ? value : undefined;
-};
-
-const toBlockRequestError = (error: unknown, method: BlockRequestMethod, url: string): BlockRequestError => {
-    if (error instanceof BlockRequestError) {
+const toBlockRequestError = (error: unknown, method: BlockRequestMethod, url: string): ApiRequestError => {
+    if (error instanceof ApiRequestError) {
         return error;
     }
 
-    const source = (typeof error === 'object' && error !== null ? error : {}) as {
-        message?: unknown;
-        status?: unknown;
-        statusCode?: unknown;
-        data?: unknown;
-        response?: BlockErrorResponse;
-    };
-
-    const status = toStatus(source.status) ?? toStatus(source.statusCode) ?? toStatus(source.response?.status);
-    const message = typeof source.message === 'string' && source.message ? source.message : 'Request failed';
-
-    return new BlockRequestError(`[${method.toUpperCase()} ${url}]${status ? ` ${status}` : ''} ${message}`, {
-        method,
-        url,
-        status,
-        data: source.data ?? source.response?.data,
-        response: source.response,
-        cause: error,
-    });
+    return toApiRequestError(error, method, url);
 };
 
 /**
  * Creates the request function used by the methods of a block (or module) SDK. It takes care of
  * merging the default API headers with the ones provided by the caller and with the access token,
- * serializing query params, typing the response and wrapping errors into {@link BlockRequestError}.
+ * serializing query params, typing the response and wrapping errors into {@link ApiRequestError}.
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## Summary

- Add the framework-level `ApiRequestError` contract for transport, HTTP, and response parsing failures.
- Normalize errors in SDK interceptors so direct SDK methods and block SDK methods share the same shape; keep `BlockRequestError` as a deprecated alias.
- Replace the frontend page status probing with typed `ApiRequestError` checks.
- Add interceptor/backstop coverage and a framework changeset.

Fixes #876

## Verification

- `npm --workspace @o2s/framework test` — 7 files, 55 tests passed.
- `npm --workspace @o2s/framework run lint` — passed.
- Framework TypeScript 7 build plus `tsc-alias` — passed.
- Local HTTP integration verified that direct and block SDK requests both produce relative-URL `ApiRequestError` instances with status and response data.

Implementation was AI-assisted; the changes were locally tested and reviewed for the requested scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized SDK request failures with `ApiRequestError`, including request details, status, response data, and original causes when available.
  * Exposed `ApiRequestError` for SDK consumers.
  * Preserved `BlockRequestError` as a deprecated compatibility alias.

* **Bug Fixes**
  * Improved handling of transport, HTTP, and response-parsing errors.
  * Updated page error handling for unauthorized and not-found responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->